### PR TITLE
fix: support develop locahost:3000

### DIFF
--- a/server/utils/commons.js
+++ b/server/utils/commons.js
@@ -115,7 +115,7 @@ exports.randStr = () => {
 exports.getIp = (ctx) => {
   let ip;
   try {
-    ip = ctx.ip.match(/\d+.\d+.\d+.\d+/)[0];
+    ip = ctx.ip.match(/\d+.\d+.\d+.\d+/) ? ctx.ip.match(/\d+.\d+.\d+.\d+/)[0] : 'localhost';
   } catch (e) {
     ip = null;
   }


### PR DESCRIPTION
在1.3.2版本上开发时，开发环境为`127.0.0.1:3000`可正常获取mock接口数据，但是`localhost:3000`下不支持.调整了下，在1.3.2版本上测试可以正常访问mock接口