### PR TITLE
fix: 实现不同group可以创建相同的项目名

### DIFF
--- a/server/controllers/project.js
+++ b/server/controllers/project.js
@@ -131,7 +131,7 @@ class projectController extends baseController {
     }
 
 
-    let checkRepeat = await this.Model.checkNameRepeat(params.name);
+    let checkRepeat = await this.Model.checkNameRepeat(params.name, params.group_id);
 
     if (checkRepeat > 0) {
       return ctx.body = yapi.commons.resReturn(null, 401, '已存在的项目名');
@@ -594,7 +594,7 @@ class projectController extends baseController {
       }
 
       if (params.name) {
-        let checkRepeat = await this.Model.checkNameRepeat(params.name);
+        let checkRepeat = await this.Model.checkNameRepeat(params.name, params.group_id);
         if (checkRepeat > 0) {
           return ctx.body = yapi.commons.resReturn(null, 401, '已存在的项目名');
         }

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -74,9 +74,10 @@ class projectModel extends baseModel {
     }).exec();
   }
 
-  checkNameRepeat(name) {
+  checkNameRepeat(name, groupid) {
     return this.model.count({
-      name: name
+      name: name,
+      group_id: groupid
     });
   }
 

--- a/static/doc/static/server/controllers/project.js.html
+++ b/static/doc/static/server/controllers/project.js.html
@@ -158,7 +158,7 @@ class projectController extends baseController {
     }
 
 
-    let checkRepeat = await this.Model.checkNameRepeat(params.name);
+    let checkRepeat = await this.Model.checkNameRepeat(params.name,params.group_id);
 
     if (checkRepeat > 0) {
       return ctx.body = yapi.commons.resReturn(null, 401, '已存在的项目名');
@@ -614,7 +614,7 @@ class projectController extends baseController {
       }
 
       if (params.name) {
-        let checkRepeat = await this.Model.checkNameRepeat(params.name);
+        let checkRepeat = await this.Model.checkNameRepeat(params.name, params.group_id);
         if (checkRepeat > 0) {
           return ctx.body = yapi.commons.resReturn(null, 401, '已存在的项目名');
         }


### PR DESCRIPTION
查看官方1.3.4没有更新这个bug:
在一个group创建项目的时候，如创建的项目名同其他group下已经存在的项目name相同，会报错:项目名重复。
个人理解：每一个group应该是单独的一个项目集合，group之间不应该有关联，包括项目名。