### PR TITLE
fix: Unhandled promise rejection

### DIFF
--- a/server/install.js
+++ b/server/install.js
@@ -140,4 +140,6 @@ function setupSql() {
 
 }
 
-install();
+if(typeof yapi.connect === 'function'){
+    install();
+}

--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -24,7 +24,9 @@ function connect(callback) {
     }
     
 
-    let db = mongoose.connect(`mongodb://${config.db.servername}:${config.db.port}/${config.db.DATABASE}`, options);
+    let db = mongoose.connect(`mongodb://${config.db.servername}:${config.db.port}/${config.db.DATABASE}`, options, function(err){
+        yapi.commons.log(err +'mongodb Authentication failed', 'error');
+    });
 
     db.then(function () {
         yapi.commons.log('mongodb load success...');


### PR DESCRIPTION
修复mongodb帐号密码配置错误时引发的错误
error: MongoError: Authentication failed.mongodb connect error
(node:69168) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Authentication failed.
(node:69168) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.