### PR TITLE
fix: handleData return undefined.

### DIFF
--- a/client/components/AceEditor/mockEditor.js
+++ b/client/components/AceEditor/mockEditor.js
@@ -143,6 +143,8 @@ function run(options) {
       return formatJson(data);
     }else if (typeof data === 'object') {
       return JSON.stringify(data, null, "  ")
+    }else{
+      return ''+data;
     }
   }
 


### PR DESCRIPTION
处理响应体既不是string也不object的情况时handleData返回的数据就成为了undefined