### PR TITLE
feat: ldap支持自定义filter和忽略searchReference事件

### DIFF
--- a/server/utils/ldap.js
+++ b/server/utils/ldap.js
@@ -1,3 +1,4 @@
+const util = require("util");
 const ldap = require("ldapjs");
 const yapi = require('../yapi.js');
 
@@ -51,13 +52,15 @@ exports.ldapQuery = (username, password) => {
       });
 
       search.on('searchReference', (referral) => {
-        if (referral) {
-          let msg ={
-            type:false,
-            message: `searchReference: ${referral}`
+        if (!ldapLogin.ignoreSearchReference) {
+          if (referral) {
+            let msg ={
+              type:false,
+              message: `searchReference: ${referral}`
+            }
+            reject(msg);
+            
           }
-          reject(msg);
-          
         }
       });
       // 查询结束
@@ -104,7 +107,7 @@ exports.ldapQuery = (username, password) => {
 
       const searchDn = ldapLogin.searchDn;
       const opts = {
-        filter: `(${ldapLogin.searchStandard}=${username})`,
+        filter: util.format(ldapLogin.searchStandard, username),
         scope: 'sub'
       };
 

--- a/server/utils/ldap.js
+++ b/server/utils/ldap.js
@@ -52,15 +52,12 @@ exports.ldapQuery = (username, password) => {
       });
 
       search.on('searchReference', (referral) => {
-        if (!ldapLogin.ignoreSearchReference) {
-          if (referral) {
-            let msg ={
-              type:false,
-              message: `searchReference: ${referral}`
-            }
-            reject(msg);
-            
+        if (referral) {
+          let msg ={
+            type:false,
+            message: `searchReference: ${referral}`
           }
+          yapi.commons.log('ldapSearch: ' + JSON.stringify(msg), 'warn')
         }
       });
       // 查询结束


### PR DESCRIPTION
1. 在config.json中，ldap.searchStandard改为支持自定义filter表达式，例如: (&(objectClass=user)(cn=%s))，其中%s会被username替换掉。
2. 忽略searchReference事件。以便适应一个目录树由多个服务器组成的场景。