### PR TITLE
fix: mongoose warning 'Error:  (node:3819) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead'

### DIFF
--- a/server/utils/db.js
+++ b/server/utils/db.js
@@ -16,7 +16,7 @@ function connect(callback) {
   mongoose.Promise = global.Promise;
 
   let config = yapi.WEBCONFIG;
-  let options = {useNewUrlParser: true };
+  let options = {useNewUrlParser: true, useCreateIndex: true};
 
   if (config.db.user) {
     options.user = config.db.user;


### PR DESCRIPTION
fix: mongoose warning 'Error:  (node:3819) DeprecationWarning: collection.ensureIndex is deprecated. Use createIndexes instead'