### PR TITLE
修复无法获取请求302 跳转前的 headers

### DIFF
--- a/common/postmanLib.js
+++ b/common/postmanLib.js
@@ -60,6 +60,7 @@ async function httpRequestByNode(options) {
       url: options.url,
       headers: options.headers,
       timeout: 5000,
+      maxRedirects: 0,
       data: options.data
     })
     return handleRes(response)


### PR DESCRIPTION
yapi服务端运行时， 有302跳转， 无法获取302跳转前的headers， 比如登录请求`/signin` 返回一个302请求， 登录请求成功的cookie会在这个请求的头部, 但是axios默认maxRedirects为5， 会自动跟随302重新定向到新页面，而新页面没有请求成功的这个cookie，从而无法获取这个cookie。 现在这里被macRedirects改为0， 让其不跟随重定向， 就可以正常获取这个cookie。 请求合并， 谢谢。 