### PR TITLE
/api/open/import_data 导入数据接口，增加url支持,比如从swagger的url获取完整json数据进行导入，调用示例：

### DIFF
--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -85,9 +85,24 @@ class openController extends baseController {
       return (ctx.body = yapi.commons.resReturn(null, 40022, 'json 不能为空'));
     }
     try {
+      if(content.indexOf('http://') === 0 || content.indexOf('https://') === 0){
+        let request = require("request");// let Promise = require('Promise');
+        let syncGet = function (url){
+            return new Promise(function(resolve, reject){
+                request.get({url : url}, function(error, response, body){
+                    if(error){
+                        reject(error);
+                    }else{
+                        resolve(body);
+                    }
+                });
+            });
+        }        
+        content = await syncGet(content);
+      }
       content = JSON.parse(content);
     } catch (e) {
-      return (ctx.body = yapi.commons.resReturn(null, 40022, 'json 格式有误'));
+      return (ctx.body = yapi.commons.resReturn(null, 40022, 'json 格式有误:' + e));
     }
 
     let menuList = await this.interfaceCatModel.list(project_id);


### PR DESCRIPTION
curl http://127.0.0.1:3000/api/open/import_data -H 'Content-Type: application/x-www-form-urlencoded' -d 'type=swagger&dataSync=merge&token=524aa51f192db5158959e0ed9c2512386c1f257407207dbb4d9b4b267ffc5daa&json=http%3A%2F%2F172.18.8.5%3A13088%2Fswagger%2Fdocs%2Fv1'