### PR TITLE
 node path 兼容windows

### DIFF
--- a/ykit.config.js
+++ b/ykit.config.js
@@ -11,6 +11,7 @@ var assetsPluginInstance = new AssetsPlugin({
 var fs = require('fs');
 var package = require('./package.json');
 var yapi = require('./server/yapi');
+var isWin = require('os').platform() === 'win32'
 
 var compressPlugin = new CompressionPlugin({
   asset: '[path].gz[query]',
@@ -78,7 +79,7 @@ module.exports = {
           defaultQuery.plugins.push(['import', { libraryName: 'antd' }]);
           return defaultQuery;
         },
-        exclude: /(tui-editor|node_modules\/(?!_?(yapi-plugin|json-schema-editor-visual)))/
+        exclude: isWin ? /(tui-editor|node_modules\\(?!_?(yapi-plugin|json-schema-editor-visual)))/ : /(tui-editor|node_modules\/(?!_?(yapi-plugin|json-schema-editor-visual)))/
       }
     }
   ],


### PR DESCRIPTION
路径分隔符 在Windows 和 Linux 不相同，
linux文件路径分隔符为 __"/"__ ，windows的文件路径分隔符为 __"\\"__ 
``` js
path.join('foo', 'bar');
// 在 OSX 和 Linux 得到 'foo/bar'
// 在 Windows 得到 'foo\\bar'
```