### PR TITLE
让pre request和pre response脚本中可以获取和设置环境变量的global和header

### DIFF
--- a/client/components/Postman/Postman.js
+++ b/client/components/Postman/Postman.js
@@ -300,7 +300,7 @@ export default class Run extends Component {
       result;
 
     try {
-      result = await crossRequest(options, this.state.pre_script, this.state.after_script);
+      result = await crossRequest(options, this.state.pre_script, this.state.after_script, this.state.env, this.state.project_id);
       result = {
         header: result.res.header,
         body: result.res.body,

--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
@@ -309,7 +309,7 @@ class InterfaceColContent extends Component {
     };
 
     try {
-      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script);
+      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script, interfaceData.env, interfaceData.project_id);
       let res = (data.res.body = json_parse(data.res.body));
       result = {
         ...options,

--- a/common/postmanLib.js
+++ b/common/postmanLib.js
@@ -7,7 +7,7 @@ const HTTP_METHOD = constants.HTTP_METHOD;
 const axios = require('axios');
 const qs = require('qs');
 const CryptoJS = require('crypto-js');
-const jsrsasign = require('jsrsasign');
+const jsrsasign = require('jsrsasign')
 
 const isNode = typeof global == 'object' && global.global === global;
 const ContentTypeMap = {
@@ -203,11 +203,86 @@ function sandboxByBrowser(context = {}, script) {
   return context;
 }
 
-async function crossRequest(defaultOptions, preScript, afterScript) {
+/**
+ * 处理环境配置中的多环境参数从头数组转为json,以环境名作为key,方便pre request脚本获取
+ */
+function handleEnvArrayToObj(env) {
+  let envJsonObj = {};
+  if (env) {
+    for (let i = 0; i < env.length; i++) {
+      let envItemObj = env[i];
+      //处理对象的global属性
+      envItemObj.global = envJsonArray2Obj(envItemObj.global);
+      //处理对象的header属性
+      envItemObj.header = envJsonArray2Obj(envItemObj.header);
+      envJsonObj[envItemObj.name] = envItemObj;
+    }
+  }
+  return envJsonObj;
+}
+
+/**
+ * 处理环境配置中的多环境从json转换为array
+ */
+function handleEnvObjToArray(envJsonObj) {
+  let envArray = [];
+  if (envJsonObj) {
+    for (let key in envJsonObj) {
+      let jsonItem = envJsonObj[key];
+      jsonItem.global = envObj2JsonArray(jsonItem.global);
+      jsonItem.header = envObj2JsonArray(jsonItem.header);
+
+      envArray.push(jsonItem);
+    }
+  }
+  return envArray;
+}
+
+/**
+ * 处理[{"name:":"2"},{"value":"221"}] 转换为便于通过属性获取值的js对象 {2:"221"}
+ */
+function envJsonArray2Obj (paramsArray) {
+  let paramsJson = {};
+  if (paramsArray) {
+    for (let i = 0, len = paramsArray.length; i < len; i++) {
+      let paramItem = paramsArray[i];
+      paramsJson[paramItem.name] = paramItem.value;
+    }
+  }
+  return paramsJson;
+}
+
+/**
+ *  转换json {"2":"221"} 为 [{"name:":"2"},{"value":"221"}]
+ */
+function envObj2JsonArray (paramsJson) {
+  let paramsArray = [];
+  if (paramsJson) {
+    for (let key in paramsJson) {
+      paramsArray.push({
+        name: key,
+        value: paramsJson[key]
+      });
+    }
+  }
+  return paramsArray;
+}
+
+function updateEnv(afterHandleEnvParams, projectId) {
+  //处理完之后将env存入数据库
+  let updateEnvParams = {
+    id: projectId,
+    env: handleEnvObjToArray(afterHandleEnvParams)
+  }
+  axios.post('/api/project/up_env', updateEnvParams)
+}
+
+async function crossRequest(defaultOptions, preScript, afterScript, envParams, projectId) {
   let options = Object.assign({}, defaultOptions);
   let urlObj = URL.parse(options.url, true),
     query = {};
   query = Object.assign(query, urlObj.query);
+  let afterHandleEnvParams = handleEnvArrayToObj(envParams);
   let context = {
     get href() {
       return urlObj.href;
@@ -229,7 +304,7 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     set caseId(val) {
       throw new Error('context.caseId 不能被赋值');
     },
-
+    envParams: afterHandleEnvParams,
     method: options.method,
     pathname: urlObj.pathname,
     query: query,
@@ -237,7 +312,6 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     requestBody: options.data,
     promise: false
   };
-
   context.utils = Object.freeze({
     _: _,
     CryptoJS: CryptoJS,
@@ -263,6 +337,7 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     });
     defaultOptions.headers = options.headers = context.requestHeader;
     defaultOptions.data = options.data = context.requestBody;
+    updateEnv(afterHandleEnvParams, projectId);
   }
 
   let data;
@@ -303,7 +378,10 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     data.res.header = context.responseHeader;
     data.res.status = context.responseStatus;
     data.runTime = context.runTime;
+
+    updateEnv(afterHandleEnvParams, projectId);
   }
+  
   return data;
 }
 

--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -307,7 +307,7 @@ class openController extends baseController {
       validRes: []
     };
     try {
-      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script);
+      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script, interfaceData.env, interfaceData.project_id);
       let res = data.res;
 
       result = Object.assign(result, {


### PR DESCRIPTION
新增代码让pre request和pre reponseo脚本能够获取和设置到环境配置中的环境变量和header的值等

比如我配置如下环境配置
![image](https://user-images.githubusercontent.com/20592210/55942768-b2ac2300-5c77-11e9-9a8f-b8955d4221a5.png)


然后我在pre-request中修改getTokenTime,通过`context.envParams.环境名称.global.getTokenTime`进行获取和设置环境变量值,`context.envParams.环境名称.header.xxx`设置和修改环境配置的header值


比如我的pre-request代码如下
```
context.envParams.get_token.global.getTokenTime = new Date().getTime();
context.envParams.get_token.header.test="success";
```

执行任意接口运行后,可以看到结果如下,header添加了设置的success属性值,同时getTokenTime的值也进行了修改,证明pre-request修改有效
![image](https://user-images.githubusercontent.com/20592210/55942822-d0798800-5c77-11e9-80b2-1c256a5babd1.png)
