### PR TITLE
让pre request和pre response脚本中可以获取和设置环境变量的global,新增swagger接口自动同步功能

### DIFF
--- a/client/components/Postman/Postman.js
+++ b/client/components/Postman/Postman.js
@@ -300,7 +300,7 @@ export default class Run extends Component {
       result;
 
     try {
-      result = await crossRequest(options, this.state.pre_script, this.state.after_script);
+      result = await crossRequest(options, this.state.pre_script, this.state.after_script, this.state.env, this.state.project_id);
       result = {
         header: result.res.header,
         body: result.res.body,

--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
@@ -309,7 +309,7 @@ class InterfaceColContent extends Component {
     };
 
     try {
-      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script);
+      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script, interfaceData.env, interfaceData.project_id);
       let res = (data.res.body = json_parse(data.res.body));
       result = {
         ...options,

--- a/client/containers/Project/Setting/ProjectInterfaceSync/index.js
+++ b/client/containers/Project/Setting/ProjectInterfaceSync/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { formatTime } from '../../../../common.js';
 import { Form, Switch, Button, Icon, Tooltip, message, Input, Select } from 'antd';
 const FormItem = Form.Item;
 const Option = Select.Option;
@@ -87,7 +88,8 @@ export default class ProjectInterfaceSync extends Component {
     this.setState({
       is_sync_open: this.props.projectMsg.is_sync_open,
       sync_cron: this.props.projectMsg.sync_cron,
-      sync_json_url: this.props.projectMsg.sync_json_url
+      sync_json_url: this.props.projectMsg.sync_json_url,
+      last_sync_time: this.props.projectMsg.last_sync_time
     });
   }
 
@@ -114,7 +116,8 @@ export default class ProjectInterfaceSync extends Component {
       tag,
       sync_cron,
       sync_json_url,
-      sync_mode
+      sync_mode,
+      last_sync_time
     } = projectMsg;
     initFormValues = {
       name,
@@ -128,7 +131,8 @@ export default class ProjectInterfaceSync extends Component {
       tag,
       sync_cron,
       sync_json_url,
-      sync_mode
+      sync_mode,
+      last_sync_time
     };
     return (
       <div className="m-panel">
@@ -143,6 +147,7 @@ export default class ProjectInterfaceSync extends Component {
               checkedChildren="开"
               unCheckedChildren="关"
             />
+            {this.state.last_sync_time ? (<div>上次更新时间:<span className="logtime">{formatTime(this.state.last_sync_time )}</span></div>) : null}
           </FormItem>
 
           {this.state.is_sync_open ? (
@@ -201,12 +206,12 @@ export default class ProjectInterfaceSync extends Component {
                 })(<Input />)}
               </FormItem>
 
-              <FormItem {...formItemLayout} label="定时cron表达式(默认每分钟更新一次)">
+              <FormItem {...formItemLayout} label={<span>类cron风格表达式(默认每分钟更新一次)&nbsp;<a href="https://github.com/node-schedule/node-schedule">参考</a></span>}>
                 {getFieldDecorator('sync_cron', {
                   rules: [
                     {
                       required: true,
-                      message: '输入正确的cron表达式!'
+                      message: '输入node-schedule的类cron表达式!'
                     }
                   ],
                   initialValue: initFormValues.sync_cron? initFormValues.sync_cron : '30 * * * * *'

--- a/client/containers/Project/Setting/ProjectInterfaceSync/index.js
+++ b/client/containers/Project/Setting/ProjectInterfaceSync/index.js
@@ -1,0 +1,226 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Form, Switch, Button, Icon, Tooltip, message, Input, Select } from 'antd';
+const FormItem = Form.Item;
+const Option = Select.Option;
+import { getProject, updateProjectSync } from '../../../../reducer/modules/project';
+
+// layout
+const formItemLayout = {
+  labelCol: {
+    lg: { offset: 1, span: 3 },
+    xs: { span: 24 },
+    sm: { span: 6 }
+  },
+  wrapperCol: {
+    lg: { span: 19 },
+    xs: { span: 24 },
+    sm: { span: 14 }
+  },
+  className: 'form-item'
+};
+const tailFormItemLayout = {
+  wrapperCol: {
+    sm: {
+      span: 16,
+      offset: 11
+    }
+  }
+};
+
+@connect(
+  state => {
+    return {
+      projectMsg: state.project.currProject
+    };
+  },
+  {
+    getProject,
+    updateProjectSync
+  }
+)
+@Form.create()
+export default class ProjectInterfaceSync extends Component {
+  static propTypes = {
+    form: PropTypes.object,
+    match: PropTypes.object,
+    projectId: PropTypes.number,
+    projectMsg: PropTypes.object,
+    getProject: PropTypes.func,
+    updateProjectSync: PropTypes.func
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      is_sync_open: false
+    };
+  }
+
+  handleSubmit = async () => {
+    const { form, projectId, updateProjectSync, getProject } = this.props;
+    let params = {
+      id: this.props.projectId,
+      is_sync_open: this.state.is_sync_open
+    };
+
+    form.validateFields((err, values) => {
+      if (!err) {
+        let assignValue = Object.assign(params, values);
+        updateProjectSync(assignValue)
+          .then(res => {
+            if (res.payload.data.errcode == 0) {
+              message.success('保存成功');
+              getProject(projectId);
+            } else {
+              message.error('保存失败, ' + res.payload.data.errmsg);
+            }
+          })
+          .catch(() => { });
+      }
+    });
+
+  };
+
+  componentWillMount() {
+    this.setState({
+      is_sync_open: this.props.projectMsg.is_sync_open,
+      sync_cron: this.props.projectMsg.sync_cron,
+      sync_json_url: this.props.projectMsg.sync_json_url
+    });
+  }
+
+  // 是否开启
+  onChange = v => {
+    this.setState({
+      is_sync_open: v
+    });
+  };
+
+  render() {
+    const { getFieldDecorator } = this.props.form;
+    const { projectMsg } = this.props;
+    let initFormValues = {};
+    const {
+      name,
+      basepath,
+      desc,
+      project_type,
+      group_id,
+      switch_notice,
+      strice,
+      is_json5,
+      tag,
+      sync_cron,
+      sync_json_url,
+      sync_mode
+    } = projectMsg;
+    initFormValues = {
+      name,
+      basepath,
+      desc,
+      project_type,
+      group_id,
+      switch_notice,
+      strice,
+      is_json5,
+      tag,
+      sync_cron,
+      sync_json_url,
+      sync_mode
+    };
+    return (
+      <div className="m-panel">
+        <Form>
+          <FormItem
+            label="是否开启自动同步"
+            {...formItemLayout}
+          >
+            <Switch
+              checked={this.state.is_sync_open}
+              onChange={this.onChange}
+              checkedChildren="开"
+              unCheckedChildren="关"
+            />
+          </FormItem>
+
+          {this.state.is_sync_open ? (
+            <div>
+              <FormItem {...formItemLayout} label={
+                <span className="label">
+                  数据同步&nbsp;
+                  <Tooltip
+                    title={
+                      <div>
+                        <h3 style={{ color: 'white' }}>普通模式</h3>
+                        <p>不导入已存在的接口</p>
+                        <br />
+                        <h3 style={{ color: 'white' }}>智能合并</h3>
+                        <p>
+                          已存在的接口，将合并返回数据的 response，适用于导入了 swagger
+                          数据，保留对数据结构的改动
+                        </p>
+                        <br />
+                        <h3 style={{ color: 'white' }}>完全覆盖</h3>
+                        <p>不保留旧数据，完全使用新数据，适用于接口定义完全交给后端定义</p>
+                      </div>
+                    }
+                  >
+                    <Icon type="question-circle-o" />
+                  </Tooltip>{' '}
+                </span>
+              }>
+                {getFieldDecorator('sync_mode', {
+                  initialValue: initFormValues.sync_mode,
+                  rules: [
+                    {
+                      required: true,
+                      message: '请选择同步方式!'
+                    }
+                  ]
+                })(
+
+                  <Select>
+                    <Option value="normal">普通模式</Option>
+                    <Option value="good">智能合并</Option>
+                    <Option value="merge">完全覆盖</Option>
+                  </Select>
+                )}
+              </FormItem>
+
+              <FormItem {...formItemLayout} label="项目的swagger地址(xxx/api/docs)">
+                {getFieldDecorator('sync_json_url', {
+                  rules: [
+                    {
+                      required: true,
+                      message: '输入swagger地址'
+                    }
+                  ],
+                  initialValue: initFormValues.sync_json_url
+                })(<Input />)}
+              </FormItem>
+
+              <FormItem {...formItemLayout} label="定时任务cron表达式">
+                {getFieldDecorator('sync_cron', {
+                  rules: [
+                    {
+                      required: true,
+                      message: '输入正确的cron表达式!'
+                    }
+                  ],
+                  initialValue: initFormValues.sync_cron
+                })(<Input />)}
+              </FormItem>
+            </div>
+          ) : null}
+          <FormItem {...tailFormItemLayout}>
+            <Button type="primary" htmlType="submit" icon="save" size="large" onClick={this.handleSubmit}>
+              保存
+            </Button>
+          </FormItem>
+        </Form>
+      </div>
+    );
+  }
+}

--- a/client/containers/Project/Setting/ProjectInterfaceSync/index.js
+++ b/client/containers/Project/Setting/ProjectInterfaceSync/index.js
@@ -5,7 +5,7 @@ import { formatTime } from '../../../../common.js';
 import { Form, Switch, Button, Icon, Tooltip, message, Input, Select } from 'antd';
 const FormItem = Form.Item;
 const Option = Select.Option;
-import { getProject, updateProjectSync } from '../../../../reducer/modules/project';
+import { getProject, updateProjectSync, handleSwaggerUrlData} from '../../../../reducer/modules/project';
 
 // layout
 const formItemLayout = {
@@ -38,7 +38,8 @@ const tailFormItemLayout = {
   },
   {
     getProject,
-    updateProjectSync
+    updateProjectSync,
+    handleSwaggerUrlData
   }
 )
 @Form.create()
@@ -49,7 +50,8 @@ export default class ProjectInterfaceSync extends Component {
     projectId: PropTypes.number,
     projectMsg: PropTypes.object,
     getProject: PropTypes.func,
-    updateProjectSync: PropTypes.func
+    updateProjectSync: PropTypes.func,
+    handleSwaggerUrlData: PropTypes.func
   };
 
   constructor(props) {
@@ -83,6 +85,15 @@ export default class ProjectInterfaceSync extends Component {
     });
 
   };
+
+  validSwaggerUrl = async (rule, value, callback) => {
+    try{
+      await this.props.handleSwaggerUrlData(value);
+    } catch(e) {
+      callback('swagger地址不正确');
+    } 
+    callback()
+  }
 
   componentWillMount() {
     this.setState({
@@ -147,7 +158,7 @@ export default class ProjectInterfaceSync extends Component {
               checkedChildren="开"
               unCheckedChildren="关"
             />
-            {this.state.last_sync_time ? (<div>上次更新时间:<span className="logtime">{formatTime(this.state.last_sync_time )}</span></div>) : null}
+            {this.state.last_sync_time ? (<div>上次更新时间:<span className="logtime">{formatTime(this.state.last_sync_time)}</span></div>) : null}
           </FormItem>
 
           {this.state.is_sync_open ? (
@@ -194,12 +205,15 @@ export default class ProjectInterfaceSync extends Component {
                 )}
               </FormItem>
 
-              <FormItem {...formItemLayout} label="项目的swagger地址(xxx/api/docs)">
+              <FormItem {...formItemLayout} label="项目的swagger json地址">
                 {getFieldDecorator('sync_json_url', {
                   rules: [
                     {
                       required: true,
                       message: '输入swagger地址'
+                    },
+                    {
+                      validator: this.validSwaggerUrl
                     }
                   ],
                   initialValue: initFormValues.sync_json_url
@@ -214,7 +228,7 @@ export default class ProjectInterfaceSync extends Component {
                       message: '输入node-schedule的类cron表达式!'
                     }
                   ],
-                  initialValue: initFormValues.sync_cron? initFormValues.sync_cron : '30 * * * * *'
+                  initialValue: initFormValues.sync_cron ? initFormValues.sync_cron : '30 * * * * *'
                 })(<Input />)}
               </FormItem>
             </div>

--- a/client/containers/Project/Setting/ProjectInterfaceSync/index.js
+++ b/client/containers/Project/Setting/ProjectInterfaceSync/index.js
@@ -9,14 +9,14 @@ import { getProject, updateProjectSync } from '../../../../reducer/modules/proje
 // layout
 const formItemLayout = {
   labelCol: {
-    lg: { offset: 1, span: 3 },
+    lg: { span: 5 },
     xs: { span: 24 },
-    sm: { span: 6 }
+    sm: { span: 10 }
   },
   wrapperCol: {
-    lg: { span: 19 },
+    lg: { span: 16 },
     xs: { span: 24 },
-    sm: { span: 14 }
+    sm: { span: 12 }
   },
   className: 'form-item'
 };
@@ -201,7 +201,7 @@ export default class ProjectInterfaceSync extends Component {
                 })(<Input />)}
               </FormItem>
 
-              <FormItem {...formItemLayout} label="定时任务cron表达式">
+              <FormItem {...formItemLayout} label="定时cron表达式(默认每分钟更新一次)">
                 {getFieldDecorator('sync_cron', {
                   rules: [
                     {
@@ -209,7 +209,7 @@ export default class ProjectInterfaceSync extends Component {
                       message: '输入正确的cron表达式!'
                     }
                   ],
-                  initialValue: initFormValues.sync_cron
+                  initialValue: initFormValues.sync_cron? initFormValues.sync_cron : '30 * * * * *'
                 })(<Input />)}
               </FormItem>
             </div>

--- a/client/containers/Project/Setting/Setting.js
+++ b/client/containers/Project/Setting/Setting.js
@@ -6,6 +6,7 @@ import ProjectEnv from './ProjectEnv/index.js';
 import ProjectRequest from './ProjectRequest/ProjectRequest';
 import ProjectToken from './ProjectToken/ProjectToken';
 import ProjectMock from './ProjectMock/index.js';
+import ProjectInterfaceSync from './ProjectInterfaceSync/index.js';
 import { connect } from 'react-redux';
 const TabPane = Tabs.TabPane;
 
@@ -43,6 +44,9 @@ class Setting extends Component {
           ) : null}
           <TabPane tab="全局mock脚本" key="5">
             <ProjectMock projectId={+id} />
+          </TabPane>
+          <TabPane tab="Swagger自动同步" key="6">
+            <ProjectInterfaceSync projectId={+id} />
           </TabPane>
         </Tabs>
       </div>

--- a/client/reducer/modules/project.js
+++ b/client/reducer/modules/project.js
@@ -256,6 +256,14 @@ export function updateProjectMock(data) {
   };
 }
 
+// 修改全局mock
+export function updateProjectSync(data) {
+  return {
+    type: PROJECT_UPDATE,
+    payload: axios.post('/api/project/up_sync', data)
+  };
+}
+
 // 修改项目环境配置
 export function updateEnv(data) {
   const { env, _id } = data;

--- a/common/postmanLib.js
+++ b/common/postmanLib.js
@@ -210,11 +210,11 @@ function handleEnvArrayToObj(env) {
   let envJsonObj = {};
   if (env) {
     for (let i = 0; i < env.length; i++) {
-      let envItemObj = env[i];
+      let envItemObj = Object.assign({}, env[i]);
       //处理对象的global属性
-      envItemObj.global = envJsonArray2Obj(envItemObj.global);
+      envItemObj.global = envJsonArray2Obj(env[i].global);
       //处理对象的header属性
-      envItemObj.header = envJsonArray2Obj(envItemObj.header);
+      envItemObj.header = envJsonArray2Obj(env[i].header);
       envJsonObj[envItemObj.name] = envItemObj;
     }
   }
@@ -228,7 +228,7 @@ function handleEnvObjToArray(envJsonObj) {
   let envArray = [];
   if (envJsonObj) {
     for (let key in envJsonObj) {
-      let jsonItem = envJsonObj[key];
+      let jsonItem = Object.assign({}, envJsonObj[key]);
       jsonItem.global = envObj2JsonArray(jsonItem.global);
       jsonItem.header = envObj2JsonArray(jsonItem.header);
 
@@ -272,7 +272,7 @@ function updateEnv(afterHandleEnvParams, projectId) {
   //处理完之后将env存入数据库
   let updateEnvParams = {
     id: projectId,
-    env: handleEnvObjToArray(afterHandleEnvParams)
+    env: afterHandleEnvParams
   }
   axios.post('/api/project/up_env', updateEnvParams)
 }
@@ -337,7 +337,7 @@ async function crossRequest(defaultOptions, preScript, afterScript, envParams, p
     });
     defaultOptions.headers = options.headers = context.requestHeader;
     defaultOptions.data = options.data = context.requestBody;
-    updateEnv(afterHandleEnvParams, projectId);
+    updateEnv(handleEnvObjToArray(afterHandleEnvParams), projectId);
   }
 
   let data;
@@ -367,7 +367,6 @@ async function crossRequest(defaultOptions, preScript, afterScript, envParams, p
       window.crossRequest(options);
     });
   }
-
   if (afterScript) {
     context.responseData = data.res.body;
     context.responseHeader = data.res.header;
@@ -378,8 +377,7 @@ async function crossRequest(defaultOptions, preScript, afterScript, envParams, p
     data.res.header = context.responseHeader;
     data.res.status = context.responseStatus;
     data.runTime = context.runTime;
-
-    updateEnv(afterHandleEnvParams, projectId);
+    updateEnv(handleEnvObjToArray(afterHandleEnvParams), projectId);
   }
   
   return data;

--- a/common/postmanLib.js
+++ b/common/postmanLib.js
@@ -7,7 +7,7 @@ const HTTP_METHOD = constants.HTTP_METHOD;
 const axios = require('axios');
 const qs = require('qs');
 const CryptoJS = require('crypto-js');
-const jsrsasign = require('jsrsasign');
+const jsrsasign = require('jsrsasign')
 
 const isNode = typeof global == 'object' && global.global === global;
 const ContentTypeMap = {
@@ -203,11 +203,86 @@ function sandboxByBrowser(context = {}, script) {
   return context;
 }
 
-async function crossRequest(defaultOptions, preScript, afterScript) {
+/**
+ * 处理环境配置中的多环境参数从头数组转为json,以环境名作为key,方便pre request脚本获取
+ */
+function handleEnvArrayToObj(env) {
+  let envJsonObj = {};
+  if (env) {
+    for (let i = 0; i < env.length; i++) {
+      let envItemObj = env[i];
+      //处理对象的global属性
+      envItemObj.global = envJsonArray2Obj(envItemObj.global);
+      //处理对象的header属性
+      envItemObj.header = envJsonArray2Obj(envItemObj.header);
+      envJsonObj[envItemObj.name] = envItemObj;
+    }
+  }
+  return envJsonObj;
+}
+
+/**
+ * 处理环境配置中的多环境从json转换为array
+ */
+function handleEnvObjToArray(envJsonObj) {
+  let envArray = [];
+  if (envJsonObj) {
+    for (let key in envJsonObj) {
+      let jsonItem = envJsonObj[key];
+      jsonItem.global = envObj2JsonArray(jsonItem.global);
+      jsonItem.header = envObj2JsonArray(jsonItem.header);
+
+      envArray.push(jsonItem);
+    }
+  }
+  return envArray;
+}
+
+/**
+ * 处理[{"name:":"2"},{"value":"221"}] 转换为便于通过属性获取值的js对象 {2:"221"}
+ */
+function envJsonArray2Obj (paramsArray) {
+  let paramsJson = {};
+  if (paramsArray) {
+    for (let i = 0, len = paramsArray.length; i < len; i++) {
+      let paramItem = paramsArray[i];
+      paramsJson[paramItem.name] = paramItem.value;
+    }
+  }
+  return paramsJson;
+}
+
+/**
+ *  转换json {"2":"221"} 为 [{"name:":"2"},{"value":"221"}]
+ */
+function envObj2JsonArray (paramsJson) {
+  let paramsArray = [];
+  if (paramsJson) {
+    for (let key in paramsJson) {
+      paramsArray.push({
+        name: key,
+        value: paramsJson[key]
+      });
+    }
+  }
+  return paramsArray;
+}
+
+function updateEnv(afterHandleEnvParams, projectId) {
+  //处理完之后将env存入数据库
+  let updateEnvParams = {
+    id: projectId,
+    env: handleEnvObjToArray(afterHandleEnvParams)
+  }
+  axios.post('/api/project/up_env', updateEnvParams)
+}
+
+async function crossRequest(defaultOptions, preScript, afterScript, envParams, projectId) {
   let options = Object.assign({}, defaultOptions);
   let urlObj = URL.parse(options.url, true),
     query = {};
   query = Object.assign(query, urlObj.query);
+  let afterHandleEnvParams = handleEnvArrayToObj(envParams);
   let context = {
     get href() {
       return urlObj.href;
@@ -229,7 +304,7 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     set caseId(val) {
       throw new Error('context.caseId 不能被赋值');
     },
-
+    envParams: afterHandleEnvParams,
     method: options.method,
     pathname: urlObj.pathname,
     query: query,
@@ -237,7 +312,6 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     requestBody: options.data,
     promise: false
   };
-
   context.utils = Object.freeze({
     _: _,
     CryptoJS: CryptoJS,
@@ -263,6 +337,7 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     });
     defaultOptions.headers = options.headers = context.requestHeader;
     defaultOptions.data = options.data = context.requestBody;
+    updateEnv(afterHandleEnvParams, projectId);
   }
 
   let data;
@@ -303,7 +378,10 @@ async function crossRequest(defaultOptions, preScript, afterScript) {
     data.res.header = context.responseHeader;
     data.res.status = context.responseStatus;
     data.runTime = context.runTime;
+
+    updateEnv(afterHandleEnvParams, projectId);
   }
+  
   return data;
 }
 

--- a/common/postmanLib.js
+++ b/common/postmanLib.js
@@ -210,11 +210,9 @@ function handleEnvArrayToObj(env) {
   let envJsonObj = {};
   if (env) {
     for (let i = 0; i < env.length; i++) {
-      let envItemObj = Object.assign({}, env[i]);
+      let envItemObj = env[i];
       //处理对象的global属性
       envItemObj.global = envJsonArray2Obj(env[i].global);
-      //处理对象的header属性
-      envItemObj.header = envJsonArray2Obj(env[i].header);
       envJsonObj[envItemObj.name] = envItemObj;
     }
   }
@@ -228,9 +226,8 @@ function handleEnvObjToArray(envJsonObj) {
   let envArray = [];
   if (envJsonObj) {
     for (let key in envJsonObj) {
-      let jsonItem = Object.assign({}, envJsonObj[key]);
+      let jsonItem =  envJsonObj[key];
       jsonItem.global = envObj2JsonArray(jsonItem.global);
-      jsonItem.header = envObj2JsonArray(jsonItem.header);
 
       envArray.push(jsonItem);
     }
@@ -368,6 +365,9 @@ async function crossRequest(defaultOptions, preScript, afterScript, envParams, p
     });
   }
   if (afterScript) {
+    if (preScript) {
+      afterHandleEnvParams = handleEnvArrayToObj(envParams);
+    }
     context.responseData = data.res.body;
     context.responseHeader = data.res.header;
     context.responseStatus = data.res.status;

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "tslib": "1.8.0",
     "underscore": "1.8.3",
     "url": "0.11.0",
-    "yapi-cli": "^1.4.0",
     "yapi-plugin-qsso": "^1.1.0"
   },
   "devDependencies": {
@@ -151,7 +150,7 @@
     "webpack-dev-middleware": "^1.12.0",
     "webpack-node-externals": "^1.6.0",
     "ydoc-plugin-img-view": "^1.0.1",
-    "ykit": "^0.6.2",
+    "ykit": "0.6.2",
     "ykit-config-antd": "0.1.3",
     "ykit-config-es6": "^1.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "mongoose": "5.3.2",
     "mongoose-auto-increment": "5.0.1",
     "moox": "^1.0.2",
+    "node-schedule": "^1.3.2",
     "nodemailer": "4.0.1",
     "os": "0.1.1",
     "request": "2.81.0",
@@ -80,6 +81,7 @@
     "tslib": "1.8.0",
     "underscore": "1.8.3",
     "url": "0.11.0",
+    "yapi-cli": "^1.4.0",
     "yapi-plugin-qsso": "^1.1.0"
   },
   "devDependencies": {
@@ -149,7 +151,7 @@
     "webpack-dev-middleware": "^1.12.0",
     "webpack-node-externals": "^1.6.0",
     "ydoc-plugin-img-view": "^1.0.1",
-    "ykit": "0.6.2",
+    "ykit": "^0.6.2",
     "ykit-config-antd": "0.1.3",
     "ykit-config-es6": "^1.1.0"
   },

--- a/server/app.js
+++ b/server/app.js
@@ -16,6 +16,9 @@ const koaStatic = require('koa-static');
 // const bodyParser = require('koa-bodyparser');
 const koaBody = require('koa-body');
 const router = require('./router.js');
+//start sync job
+const interfaceSyncUtils = require('./utils/interfaceSyncUtils.js')
+yapi.getInst(interfaceSyncUtils)
 
 let indexFile = process.argv[2] === 'dev' ? 'dev.html' : 'index.html';
 

--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -307,7 +307,7 @@ class openController extends baseController {
       validRes: []
     };
     try {
-      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script);
+      let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script, interfaceData.env, interfaceData.project_id);
       let res = data.res;
 
       result = Object.assign(result, {

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -41,6 +41,10 @@ class projectModel extends baseModel {
       sync_json_url: String,
       //接口合并模式  good,nomarl等等 意思也就是智能合并,完全覆盖等
       sync_mode: String,
+      //上次成功同步接口时间,
+      last_sync_time: Number,
+      //上次同步的swagger 文档内容
+      old_swagger_content: String,
       strice: { type: Boolean, default: false },
       is_json5: { type: Boolean, default: true },
       tag: [{name: String, desc: String}]
@@ -93,7 +97,7 @@ class projectModel extends baseModel {
   getBaseInfo(id, select) {
     select =
       select ||
-      '_id uid name basepath switch_notice desc group_id project_type env icon color add_time up_time pre_script after_script project_mock_script is_mock_open is_sync_open sync_cron sync_json_url sync_mode strice is_json5 tag';
+      '_id uid name basepath switch_notice desc group_id project_type env icon color add_time up_time pre_script after_script project_mock_script is_mock_open is_sync_open sync_cron sync_json_url sync_mode old_swagger_content last_sync_time strice is_json5 tag';
     return this.model
       .findOne({
         _id: id
@@ -139,7 +143,7 @@ class projectModel extends baseModel {
     return this.model
       .find({})
       .select(
-        '_id uid name basepath switch_notice desc group_id project_type color icon env add_time up_time is_sync_open sync_cron sync_json_url sync_mode'
+        '_id uid name basepath switch_notice desc group_id project_type color icon env add_time up_time is_sync_open sync_cron sync_json_url sync_mode old_swagger_content last_sync_time'
       )
       .sort({ _id: -1 })
       .exec();

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -33,6 +33,10 @@ class projectModel extends baseModel {
       after_script: String,
       project_mock_script: String,
       is_mock_open: { type: Boolean, default: false },
+      is_sync_open: { type: Boolean, default: false },
+      sync_cron: String,
+      sync_json_url: String,
+      sync_mode: String,
       strice: { type: Boolean, default: false },
       is_json5: { type: Boolean, default: true },
       tag: [{name: String, desc: String}]
@@ -85,7 +89,7 @@ class projectModel extends baseModel {
   getBaseInfo(id, select) {
     select =
       select ||
-      '_id uid name basepath switch_notice desc group_id project_type env icon color add_time up_time pre_script after_script project_mock_script is_mock_open strice is_json5 tag';
+      '_id uid name basepath switch_notice desc group_id project_type env icon color add_time up_time pre_script after_script project_mock_script is_mock_open is_sync_open sync_cron sync_json_url sync_mode strice is_json5 tag';
     return this.model
       .findOne({
         _id: id
@@ -122,6 +126,16 @@ class projectModel extends baseModel {
       .find(params)
       .select(
         '_id uid name basepath switch_notice desc group_id project_type color icon env add_time up_time'
+      )
+      .sort({ _id: -1 })
+      .exec();
+  }
+
+  listAll() {
+    return this.model
+      .find({})
+      .select(
+        '_id uid name basepath switch_notice desc group_id project_type color icon env add_time up_time is_sync_open sync_cron sync_json_url sync_mode'
       )
       .sort({ _id: -1 })
       .exec();

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -33,9 +33,13 @@ class projectModel extends baseModel {
       after_script: String,
       project_mock_script: String,
       is_mock_open: { type: Boolean, default: false },
+      //是否开启自动同步
       is_sync_open: { type: Boolean, default: false },
+      //自动同步定时任务的cron表达式
       sync_cron: String,
+      //自动同步获取json的url
       sync_json_url: String,
+      //接口合并模式  good,nomarl等等 意思也就是智能合并,完全覆盖等
       sync_mode: String,
       strice: { type: Boolean, default: false },
       is_json5: { type: Boolean, default: true },

--- a/server/router.js
+++ b/server/router.js
@@ -4,6 +4,7 @@ const groupController = require('./controllers/group.js');
 const userController = require('./controllers/user.js');
 const interfaceColController = require('./controllers/interfaceCol.js');
 const testController = require('./controllers/test.js');
+const tokenController = require('./controllers/token.js');
 
 const yapi = require('./yapi.js');
 const projectController = require('./controllers/project.js');
@@ -259,6 +260,11 @@ let routerConfig = {
     {
       action: 'upEnv',
       path: 'up_env',
+      method: 'post'
+    },
+    {
+      action: 'upSync',
+      path: 'up_sync',
       method: 'post'
     },
     {

--- a/server/router.js
+++ b/server/router.js
@@ -4,7 +4,6 @@ const groupController = require('./controllers/group.js');
 const userController = require('./controllers/user.js');
 const interfaceColController = require('./controllers/interfaceCol.js');
 const testController = require('./controllers/test.js');
-const tokenController = require('./controllers/token.js');
 
 const yapi = require('./yapi.js');
 const projectController = require('./controllers/project.js');

--- a/server/utils/interfaceSyncUtils.js
+++ b/server/utils/interfaceSyncUtils.js
@@ -1,0 +1,134 @@
+const schedule = require('node-schedule');
+const openController = require('../controllers/open.js');
+const projectModel = require('../models/project.js')
+const tokenModel = require('../models/token.js')
+const yapi = require('../yapi.js')
+const sha = require('sha.js');
+const {getToken} = require('../utils/token')
+const jobMap = new Map();
+
+class syncUtils {
+
+    constructor(ctx) {
+        yapi.commons.log("-------------------------------------interfaceSyncUtils constructor-----------------------------------------------");
+        this.ctx = ctx;
+        this.openController = yapi.getInst(openController);
+        this.tokenModel = yapi.getInst(tokenModel)
+        this.projectModel = yapi.getInst(projectModel);
+        this.init()
+    }
+
+    //初始化定时任务
+    async init() {
+        let allProject = await this.projectModel.listAll();
+        for (let i = 0, len = allProject.length; i < len; i++) {
+            let projectItem = allProject[i];
+            if (projectItem.is_sync_open) {
+                this.addSyncJob(projectItem._id, projectItem.sync_cron, projectItem.sync_json_url, projectItem.sync_mode, projectItem.uid);
+            }
+        }
+    }
+
+    /**
+     * 新增同步任务.
+     * @param {*} projectId 项目id
+     * @param {*} cronExpression cron表达式,针对定时任务
+     * @param {*} swaggerUrl 获取swagger的地址
+     * @param {*} syncMode 同步模式
+     * @param {*} uid 用户id
+     */
+    async addSyncJob(projectId, cronExpression, swaggerUrl, syncMode, uid) {
+        let projectToken = await this.getProjectToken(projectId, uid);
+
+        let scheduleItem = schedule.scheduleJob(cronExpression, async ()=>{
+            yapi.commons.log('定时器触发, syncJsonUrl:' + swaggerUrl +",合并模式:" + syncMode);
+            let _params = {
+                type: 'swagger',
+                url: swaggerUrl,
+                project_id: projectId,
+                merge: syncMode,
+                token: projectToken
+            }
+            let requestObj = {
+                params: _params
+            };
+            await this.openController.importData(requestObj);
+
+            //记录日志
+            yapi.commons.saveLog({
+                content: '自动同步接口状态:' + (requestObj.body.errcode == 0? '成功,' : '失败,') + "合并模式:" + this.getSyncModeName(syncMode) + ",更多信息:" + requestObj.body.errmsg,
+                type: 'project',
+                uid: uid,
+                username: "自动同步用户",
+                typeid: projectId
+            });
+        });
+
+        let jobItem = jobMap.get(projectId);
+        if (jobItem) {
+            jobItem.cancel();
+        }
+        jobMap.set(projectId, scheduleItem);
+    }
+
+    /**
+     * 获取项目token,因为导入接口需要鉴权.
+     * @param {*} project_id 项目id
+     * @param {*} uid 用户id
+     */
+    async getProjectToken(project_id, uid) {
+      try {
+        let data = await this.tokenModel.get(project_id);
+        let token;
+        if (!data) {
+          let passsalt = yapi.commons.randStr();
+          token = sha('sha1')
+            .update(passsalt)
+            .digest('hex')
+            .substr(0, 20);
+  
+          await this.tokenModel.save({ project_id, token });
+        } else {
+          token = data.token;
+        }
+  
+        token = getToken(token, uid);
+  
+        return token;
+      } catch (err) {
+          return "";
+      }
+    }
+
+    getUid(uid) {
+        return parseInt(uid, 10);
+    }
+
+    /**
+     * 转换合并模式的值为中文.
+     * @param {*} syncMode 合并模式
+     */
+    getSyncModeName(syncMode) {
+        if (syncMode == 'good') {
+            return '智能合并';
+        } else if (syncMode == 'normal') {
+            return '普通模式';
+        } else if (syncMode == 'merge') {
+            return '完全覆盖';
+        }
+        return '';
+    }
+
+    getSyncJob(projectId) {
+        return jobMap.get(projectId);
+    }
+
+    deleteSyncJob(projectId) {
+        let jobItem = jobMap.get(projectId);
+        if (jobItem) {
+            jobItem.cancel();
+        }
+    }
+}
+
+module.exports = syncUtils;

--- a/server/utils/interfaceSyncUtils.js
+++ b/server/utils/interfaceSyncUtils.js
@@ -1,10 +1,11 @@
 const schedule = require('node-schedule');
 const openController = require('../controllers/open.js');
-const projectModel = require('../models/project.js')
-const tokenModel = require('../models/token.js')
+const projectModel = require('../models/project.js');
+const tokenModel = require('../models/token.js');
 const yapi = require('../yapi.js')
 const sha = require('sha.js');
-const {getToken} = require('../utils/token')
+const md5 = require('md5');
+const { getToken } = require('../utils/token');
 const jobMap = new Map();
 
 class syncUtils {
@@ -40,11 +41,30 @@ class syncUtils {
     async addSyncJob(projectId, cronExpression, swaggerUrl, syncMode, uid) {
         let projectToken = await this.getProjectToken(projectId, uid);
 
-        let scheduleItem = schedule.scheduleJob(cronExpression, async ()=>{
-            yapi.commons.log('定时器触发, syncJsonUrl:' + swaggerUrl +",合并模式:" + syncMode);
+        let scheduleItem = schedule.scheduleJob(cronExpression, async () => {
+            yapi.commons.log('定时器触发, syncJsonUrl:' + swaggerUrl + ",合并模式:" + syncMode);
+            
+            let oldPorjectData = await this.projectModel.get(projectId);
+            let newSwaggerJsonData = await this.getSwaggerContent(swaggerUrl);
+
+            //判断获取的json数据是否正确
+            if(!newSwaggerJsonData || newSwaggerJsonData.indexOf('error') != -1) {
+                //记录日志
+                this.saveSyncLog(0, syncMode, newSwaggerJsonData, uid, projectId);
+                return;
+            }
+            //更新之前判断本次swagger json数据是否跟上次的相同,相同则不更新
+            if (oldPorjectData.old_swagger_content && oldPorjectData.old_swagger_content == md5(newSwaggerJsonData)) {
+                //记录日志
+                this.saveSyncLog(0, syncMode, "接口无更新", uid, projectId);
+                oldPorjectData.last_sync_time = yapi.commons.time();
+                await this.projectModel.up(projectId, oldPorjectData);
+                return;
+            }
+
             let _params = {
                 type: 'swagger',
-                url: swaggerUrl,
+                json: newSwaggerJsonData,
                 project_id: projectId,
                 merge: syncMode,
                 token: projectToken
@@ -53,22 +73,52 @@ class syncUtils {
                 params: _params
             };
             await this.openController.importData(requestObj);
+            
+            //修改project的属性
+            oldPorjectData.last_sync_time = yapi.commons.time();
+            oldPorjectData.old_swagger_content = md5(newSwaggerJsonData);
+            await this.projectModel.up(projectId, oldPorjectData);
 
             //记录日志
-            yapi.commons.saveLog({
-                content: '自动同步接口状态:' + (requestObj.body.errcode == 0? '成功,' : '失败,') + "合并模式:" + this.getSyncModeName(syncMode) + ",更多信息:" + requestObj.body.errmsg,
-                type: 'project',
-                uid: uid,
-                username: "自动同步用户",
-                typeid: projectId
-            });
+            this.saveSyncLog(requestObj.body.errcode, syncMode, requestObj.body.errmsg, uid, projectId);
         });
 
+        //判断是否已经存在这个任务
         let jobItem = jobMap.get(projectId);
         if (jobItem) {
             jobItem.cancel();
         }
         jobMap.set(projectId, scheduleItem);
+    }
+
+
+    getSyncJob(projectId) {
+        return jobMap.get(projectId);
+    }
+
+    deleteSyncJob(projectId) {
+        let jobItem = jobMap.get(projectId);
+        if (jobItem) {
+            jobItem.cancel();
+        }
+    }
+
+    /**
+     * 记录同步日志
+     * @param {*} errcode 
+     * @param {*} syncMode 
+     * @param {*} moremsg 
+     * @param {*} uid 
+     * @param {*} projectId 
+     */
+    saveSyncLog(errcode, syncMode, moremsg, uid, projectId) {
+        yapi.commons.saveLog({
+            content: '自动同步接口状态:' + (errcode == 0 ? '成功,' : '失败,') + "合并模式:" + this.getSyncModeName(syncMode) + ",更多信息:" + moremsg,
+            type: 'project',
+            uid: uid,
+            username: "自动同步用户",
+            typeid: projectId
+        });
     }
 
     /**
@@ -77,27 +127,27 @@ class syncUtils {
      * @param {*} uid 用户id
      */
     async getProjectToken(project_id, uid) {
-      try {
-        let data = await this.tokenModel.get(project_id);
-        let token;
-        if (!data) {
-          let passsalt = yapi.commons.randStr();
-          token = sha('sha1')
-            .update(passsalt)
-            .digest('hex')
-            .substr(0, 20);
-  
-          await this.tokenModel.save({ project_id, token });
-        } else {
-          token = data.token;
+        try {
+            let data = await this.tokenModel.get(project_id);
+            let token;
+            if (!data) {
+                let passsalt = yapi.commons.randStr();
+                token = sha('sha1')
+                    .update(passsalt)
+                    .digest('hex')
+                    .substr(0, 20);
+
+                await this.tokenModel.save({ project_id, token });
+            } else {
+                token = data.token;
+            }
+
+            token = getToken(token, uid);
+
+            return token;
+        } catch (err) {
+            return "";
         }
-  
-        token = getToken(token, uid);
-  
-        return token;
-      } catch (err) {
-          return "";
-      }
     }
 
     getUid(uid) {
@@ -119,16 +169,30 @@ class syncUtils {
         return '';
     }
 
-    getSyncJob(projectId) {
-        return jobMap.get(projectId);
+    async getSwaggerContent(swaggerUrl) {
+        let content = '';
+        try {
+            let request = require("request");// let Promise = require('Promise');
+            let syncGet = function (url) {
+                return new Promise(function (resolve, reject) {
+                    request.get({ url: url }, function (error, response, body) {
+                        if (error) {
+                            reject(error);
+                        } else {
+                            resolve(body);
+                        }
+                    });
+                });
+            }
+            if (swaggerUrl) {
+                content = await syncGet(swaggerUrl);
+            } 
+        } catch (e) {
+            return 'error:json格式有误:' + e;
+        }
+        return content;
     }
 
-    deleteSyncJob(projectId) {
-        let jobItem = jobMap.get(projectId);
-        if (jobItem) {
-            jobItem.cancel();
-        }
-    }
 }
 
 module.exports = syncUtils;


### PR DESCRIPTION
新增代码让pre request和pre reponseo脚本能够获取和设置到环境配置中global的值等

比如我配置如下环境配置
![image](https://user-images.githubusercontent.com/20592210/55942768-b2ac2300-5c77-11e9-9a8f-b8955d4221a5.png)


然后我在pre-request中修改getTokenTime,通过`context.envParams.环境名称.global.属性名`进行获取和设置环境变量值


比如我的pre-request代码如下,get_token是我的环境变量名,getTokenTime是我的变量名
```
context.envParams.get_token.global.getTokenTime = new Date().getTime();
```

执行任意接口运行后,可以看到结果如下,getTokenTime的值进行了修改,证明pre-request脚本中修改有效,并且pre request script中修改的值在pre response script就能获取到
![image](https://user-images.githubusercontent.com/20592210/56008013-424fe100-5d0d-11e9-9a7e-3e008f3989d4.png)

