### PR TITLE
fix:导出markdown文档路径参数在某些编辑器下显示错位的问题

### DIFF
--- a/common/markdown.js
+++ b/common/markdown.js
@@ -92,7 +92,7 @@ function createReqHeaders(req_headers) {
 function createPathParams(req_params) {
   if (req_params && req_params.length) {
     let paramsTable = `**路径参数**\n\n`;
-    paramsTable += `| 参数名称 | 示例  | 备注  |\n| ------------ | ------------ | ------------ | ------------ | ------------ |\n`;
+    paramsTable += `| 参数名称 | 示例  | 备注  |\n| ------------ | ------------ | ------------ |\n`;
     for (let j = 0; j < req_params.length; j++) {
       paramsTable += `| ${req_params[j].name || ''} |  ${handleWrap(req_params[j].example) ||
         ''} |  ${handleWrap(req_params[j].desc) || ''} |\n`;


### PR DESCRIPTION
### 修改前: 

**路径参数**

| 参数名称 | 示例  | 备注  |
| ------------ | ------------ | ------------ | ------------ | ------------ |
| id |   |  角色id |

### 修改后:

**路径参数**

| 参数名称 | 示例  | 备注  |
| ------------ | ------------ | ------------ |
| id |   |  角色id |


