### PR TITLE
fixed bugs 编辑接口的时候删除请求参数再次点批量添加会报错

### DIFF
--- a/client/containers/Project/Interface/InterfaceList/InterfaceEditForm.js
+++ b/client/containers/Project/Interface/InterfaceList/InterfaceEditForm.js
@@ -407,6 +407,7 @@ class InterfaceEditForm extends Component {
   delParams = (key, name) => {
     let curValue = this.props.form.getFieldValue(name);
     let newValue = {};
+    if (curValue.length === 1) return;
     newValue[name] = curValue.filter((val, index) => {
       return index !== key;
     });
@@ -548,8 +549,9 @@ class InterfaceEditForm extends Component {
 
     this.state.bulkValue.split('\n').forEach((item, index) => {
       let valueItem = Object.assign({}, curValue[index] || dataTpl[this.state.bulkName]);
-      valueItem.name = item.split(':')[0];
-      valueItem.example = item.split(':')[1] || '';
+      // valueItem.name = item.split(':')[0];
+      // valueItem.example = item.split(':')[1] || '';
+      [valueItem.name , valueItem.example, valueItem.desc] = item.split(':') || '';
       newValue.push(valueItem);
     });
 
@@ -575,7 +577,11 @@ class InterfaceEditForm extends Component {
 
     let bulkValue = ``;
     value.forEach(item => {
-      return (bulkValue += item.name ? `${item.name}:${item.example || ''}\n` : '');
+      let query = '';
+      if (item.name) query = `${item.name}:`;
+      if (item.example) query += `${item.example}:`;
+      if (item.desc) query += `${item.desc}`;
+      return (bulkValue += `${query}\n`);
     });
 
     this.setState({
@@ -809,7 +815,7 @@ class InterfaceEditForm extends Component {
         >
           <div>
             <TextArea
-              placeholder="每行一个name:examples"
+              placeholder="每行一个name : examples : desc，注意examples中不得含有英文冒号 ':'"
               autosize={{ minRows: 6, maxRows: 10 }}
               value={this.state.bulkValue}
               onChange={this.handleBulkValueInput}


### PR DESCRIPTION
### 修复了一个bug
-  在编辑接口-请求参数设置的时候，如果删除了全部的参数再次点击批量添加的时候会报错
![QQ截图20190416162954](https://user-images.githubusercontent.com/25680946/56266186-3786b900-611e-11e9-9295-8729bedfc322.png)
![QQ截图20190416163030](https://user-images.githubusercontent.com/25680946/56266192-39e91300-611e-11e9-851e-b163d198f3ff.png)

### 增加了一个新特性
-  批量添加的时候，很多时候我们也需要批量添加备注信息。如果参数名和例子能支持批量导入，备注缺不支持，在操作上会有些不便捷。因此添加了支持批量导入备注的功能。需要注意的地方就是例子的数据不能含有英文冒号，因为分隔符就是英文冒号，否则会造成数据丢失

