### PR TITLE
 fix: 解决md显示直接mock数据和接口描述为undefined的问题

### DIFF
--- a/common/markdown.js
+++ b/common/markdown.js
@@ -25,7 +25,8 @@ const messageMap = {
   itemType: 'item 类型',
   format: 'format',
   enum: '枚举',
-  enumDesc: '枚举备注'
+  enumDesc: '枚举备注',
+  mock: 'mock'
 };
 
 const columns = [
@@ -69,7 +70,7 @@ function createBaseMessage(basepath, inter) {
   // 基本信息
   let baseMessage = `### 基本信息\n\n**Path：** ${basepath + inter.path}\n\n**Method：** ${
     inter.method
-  }\n\n**接口描述：**\n${inter.desc}\n`;
+  }\n\n**接口描述：**\n${inter.desc ? inter.desc : ""}\n`;
   return baseMessage;
 }
 

--- a/common/markdown.js
+++ b/common/markdown.js
@@ -70,7 +70,7 @@ function createBaseMessage(basepath, inter) {
   // 基本信息
   let baseMessage = `### 基本信息\n\n**Path：** ${basepath + inter.path}\n\n**Method：** ${
     inter.method
-  }\n\n**接口描述：**\n${inter.desc ? inter.desc : ""}\n`;
+  }\n\n**接口描述：**\n${_.isUndefined(inter.desc) ? '' : inter.desc}\n`;
   return baseMessage;
 }
 


### PR DESCRIPTION
目前数据导出的时候，直接mock的数据会显示为undefined: @ip这种，默认没有接口描述也会显示为undefined