### PR TITLE
fix: 修复没有请求配置的情况下执行服务端测试，出线global变量为null导致的白屏等问题

### DIFF
--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -308,12 +308,16 @@ class openController extends baseController {
     try {
       let envObj = interfaceData.env.toObject();
       let data = await crossRequest(options, interfaceData.pre_script, interfaceData.after_script, envObj, interfaceData.project_id, false);
-      //更新project的env
-      let upParams = {
-        up_time: yapi.commons.time(),
-        env: envObj
-      };
-      await this.projectModel.up(interfaceData.project_id, upParams);
+      //如果pre_script和after_script有不为空的就需要修改env
+      if (interfaceData.pre_script || interfaceData.after_script) {
+        //更新project的env
+        let upParams = {
+          up_time: yapi.commons.time(),
+          env: envObj
+        };
+        await this.projectModel.up(interfaceData.project_id, upParams);
+      }
+      
       let res = data.res;
 
       result = Object.assign(result, {


### PR DESCRIPTION
fix: 修复没有请求配置的情况下执行服务端测试，出线global变量为null导致的白屏等问题

**原因**：我再postmanLib中对原有的环境变量env进行了array to obj的处理，在有脚本的情况下都会再次obj to array写入mongodb，这样没有问题。
但是在服务端测试情况下，没有pre prequest和pre response，在转为json后，对原有的array to obj之后没有进行转回来的处理就写入了mongodb导致...背锅。