### PR TITLE
opti: filtering interface on the server instead of client

### DIFF
--- a/client/containers/Project/Interface/InterfaceList/InterfaceList.js
+++ b/client/containers/Project/Interface/InterfaceList/InterfaceList.js
@@ -43,6 +43,7 @@ class InterfaceList extends Component {
     this.state = {
       visible: false,
       data: [],
+      filteredInfo: {},
       catid: null,
       total: null,
       current: 1
@@ -75,18 +76,21 @@ class InterfaceList extends Component {
       let option = {
         page: this.state.current,
         limit,
-        project_id: projectId
+        project_id: projectId,
+        status: this.state.filteredInfo.status,
+        tag: this.state.filteredInfo.tag
       };
       await this.props.fetchInterfaceList(option);
     } else if (isNaN(params.actionId)) {
       let catid = params.actionId.substr(4);
-      this.setState({ catid: +catid });
+      this.setState({catid: +catid});
       let option = {
         page: this.state.current,
         limit,
-        catid
+        catid,
+        status: this.state.filteredInfo.status,
+        tag: this.state.filteredInfo.tag
       };
-
       await this.props.fetchInterfaceCatList(option);
     }
   };
@@ -109,10 +113,13 @@ class InterfaceList extends Component {
       message.success('接口集合简介更新成功');
     });
   };
+
   handleChange = (pagination, filters, sorter) => {
     this.setState({
-      sortedInfo: sorter
-    });
+      current: pagination.current || 1,
+      sortedInfo: sorter,
+      filteredInfo: filters
+    }, () => this.handleRequest(this.props));
   };
 
   componentWillMount() {
@@ -176,20 +183,25 @@ class InterfaceList extends Component {
     }
   };
 
-  changePage = current => {
-    this.setState(
-      {
-        current: current
-      },
-      () => this.handleRequest(this.props)
-    );
-  };
+  //page change will be processed in handleChange by pagination
+  // changePage = current => {
+  //   if (this.state.current !== current) {
+  //     this.setState(
+  //       {
+  //         current: current
+  //       },
+  //       () => this.handleRequest(this.props)
+  //     );
+  //   }
+  // };
 
   render() {
     let tag = this.props.curProject.tag;
-    let filter = tag.map(item => {
-      return { text: item.name, value: item.name };
+    let tagFilter = tag.map(item => {
+      return {text: item.name, value: item.name};
     });
+    let {filteredInfo} = this.state;
+    filteredInfo = filteredInfo || {};
 
     const columns = [
       {
@@ -299,7 +311,7 @@ class InterfaceList extends Component {
           let textMsg = text.length > 0 ? text.join('\n') : '未设置';
           return <div className="table-desc">{textMsg}</div>;
         },
-        filters: filter,
+        filters: tagFilter,
         onFilter: (value, record) => {
           return record.tag.indexOf(value) >= 0;
         }
@@ -341,8 +353,8 @@ class InterfaceList extends Component {
     const pageConfig = {
       total: total,
       pageSize: limit,
-      current: this.state.current,
-      onChange: this.changePage
+      current: this.state.current
+      // onChange: this.changePage
     };
 
     const isDisabled = this.props.catList.length === 0;

--- a/client/reducer/modules/interface.js
+++ b/client/reducer/modules/interface.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import qs from 'qs';
 // Actions
 const INIT_INTERFACE_DATA = 'yapi/interface/INIT_INTERFACE_DATA';
 const FETCH_INTERFACE_DATA = 'yapi/interface/FETCH_INTERFACE_DATA';
@@ -93,7 +94,7 @@ export function updateInterfaceData(updata) {
 }
 
 export async function deleteInterfaceData(id) {
-  let result = await axios.post('/api/interface/del', { id: id });
+  let result = await axios.post('/api/interface/del', {id: id});
   return {
     type: DELETE_INTERFACE_DATA,
     payload: result
@@ -109,7 +110,7 @@ export async function saveImportData(data) {
 }
 
 export async function deleteInterfaceCatData(id) {
-  let result = await axios.post('/api/interface/del_cat', { catid: id });
+  let result = await axios.post('/api/interface/del_cat', {catid: id});
   return {
     type: DELETE_INTERFACE_CAT_DATA,
     payload: result
@@ -134,7 +135,12 @@ export async function fetchInterfaceListMenu(projectId) {
 }
 
 export async function fetchInterfaceList(params) {
-  let result = await axios.get('/api/interface/list', { params });
+  let result = await axios.get('/api/interface/list', {
+    params,
+    paramsSerializer: params => {
+      return qs.stringify(params, {indices: false})
+    }
+  })
   return {
     type: FETCH_INTERFACE_LIST,
     payload: result
@@ -142,7 +148,12 @@ export async function fetchInterfaceList(params) {
 }
 
 export async function fetchInterfaceCatList(params) {
-  let result = await axios.get('/api/interface/list_cat', { params });
+  let result = axios.get('/api/interface/list_cat', {
+    params,
+    paramsSerializer: params => {
+      return qs.stringify(params, {indices: false})
+    }
+  })
   return {
     type: FETCH_INTERFACE_CAT_LIST,
     payload: result

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "tslib": "1.8.0",
     "underscore": "1.8.3",
     "url": "0.11.0",
-    "yapi-plugin-qsso": "^1.1.0"
+    "yapi-plugin-qsso": "^1.1.0",
+    "qs": "^6.7.0"
   },
   "devDependencies": {
     "antd": "3.2.2",

--- a/server/models/interface.js
+++ b/server/models/interface.js
@@ -239,6 +239,20 @@ class interfaceModel extends baseModel {
       .exec();
   }
 
+  listByOptionWithPage(option, page, limit) {
+    page = parseInt(page);
+    limit = parseInt(limit);
+    return this.model
+      .find(option)
+      .sort({index: 1})
+      .skip((page - 1) * limit)
+      .limit(limit)
+      .select(
+        '_id title uid path method project_id catid edit_uid api_opened status add_time up_time, index, tag'
+      )
+      .exec();
+  }
+
   listByInterStatus(catid, status) {
     let option = {};
     if (status === 'open') {


### PR DESCRIPTION
将接口过滤放在服务端,效果如下:
![image](https://user-images.githubusercontent.com/17569144/61381805-32343880-a8de-11e9-9e3b-83464d0d4fa2.png)

fix #1221
fix #1052 