### PR TITLE
opti: filter search result by auth

### DIFF
--- a/server/controllers/project.js
+++ b/server/controllers/project.js
@@ -1079,6 +1079,10 @@ class projectController extends baseController {
     let groupList = await this.groupModel.search(q);
     let interfaceList = await this.interfaceModel.search(q);
 
+    projectList = await this.filterByAuth(projectList, "project");
+    groupList = await this.filterByAuth(groupList, "group");
+    interfaceList = await this.filterByAuth(interfaceList, "interface");
+
     let projectRules = [
       '_id',
       'name',

--- a/server/models/group.js
+++ b/server/models/group.js
@@ -51,6 +51,14 @@ class groupModel extends baseModel {
       .exec();
   }
 
+  getByIds(ids) {
+    return this.model
+      .find({
+        _id: {'$in': ids}
+      })
+      .exec();
+  }
+
   updateMember(data) {
     return this.model.update(
       {

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -30,8 +30,8 @@ class projectModel extends baseModel {
         }
       ],
       env: [{ name: String, domain: String, header: Array, global: [{
-        name: String,
-        value: String
+          name: String,
+          value: String
       }] }],
       icon: String,
       color: String,
@@ -82,7 +82,7 @@ class projectModel extends baseModel {
         return item;
       })
     }
-    
+
     if(isFix){
       this.model.update(
         {
@@ -104,6 +104,19 @@ class projectModel extends baseModel {
         _id: id
       })
       .exec().then(this.handleEnvNullData)
+  }
+
+  getByIds(ids) {
+    return this.model
+      .find({
+        _id: {'$in': ids}
+      })
+      .exec().then(projects => {
+        if (projects) {
+          projects.forEach(this.handleEnvNullData);
+        }
+        return projects;
+      });
   }
 
   getByEnv(id) {

--- a/server/utils/commons.js
+++ b/server/utils/commons.js
@@ -47,7 +47,7 @@ const defaultOptions = {
 
 exports.schemaToJson = function(schema, options = {}) {
   Object.assign(options, defaultOptions);
-  
+
   jsf.option(options);
   let result;
   try {
@@ -421,7 +421,7 @@ exports.createAction = (router, baseurl, routerController, action, path, method,
       await inst.init(ctx);
       ctx.params = Object.assign({}, ctx.request.query, ctx.request.body, ctx.params);
       if (inst.schemaMap && typeof inst.schemaMap === 'object' && inst.schemaMap[action]) {
-        
+
         let validResult = yapi.commons.validateParams(inst.schemaMap[action], ctx.params);
 
         if (!validResult.valid) {
@@ -547,7 +547,7 @@ exports.runCaseScript = async function runCaseScript(params, colId, interfaceId)
         throw ('Http status code 不是 200，请检查(该规则来源于于 [测试集->通用规则配置] )')
       }
     }
-  
+
     if(colData.checkResponseField.enable){
       if(params.response.body[colData.checkResponseField.name] != colData.checkResponseField.value){
         throw (`返回json ${colData.checkResponseField.name} 值不是${colData.checkResponseField.value}，请检查(该规则来源于于 [测试集->通用规则配置] )`)
@@ -637,12 +637,13 @@ exports.sendNotice = async function(projectId, data) {
 };
 
 function arrUnique(arr1, arr2) {
-  let arr = arr1.concat(arr2);
-  let res = arr.filter(function(item, index, arr) {
+  let arr = arr2 ? arr1.concat(arr2) : arr1;
+  let res = arr.filter(function (item, index, arr) {
     return arr.indexOf(item) === index;
   });
   return res;
 }
+exports.arrUnique = arrUnique
 
 // 处理mockJs脚本
 exports.handleMockScript = function(script, context) {
@@ -661,9 +662,9 @@ exports.handleMockScript = function(script, context) {
 
   context.ctx.header.cookie &&
     context.ctx.header.cookie.split(';').forEach(function(Cookie) {
-      var parts = Cookie.split('=');
-      sandbox.cookie[parts[0].trim()] = (parts[1] || '').trim();
-    });
+    var parts = Cookie.split('=');
+    sandbox.cookie[parts[0].trim()] = (parts[1] || '').trim();
+  });
   sandbox = yapi.commons.sandbox(sandbox, script);
   sandbox.delay = isNaN(sandbox.delay) ? 0 : +sandbox.delay;
 


### PR DESCRIPTION
## 对全局搜索的结果进行权限过滤,仅展示有浏览权限的信息
- 鉴于当前权限的实现方式,这里的过滤实现逻辑是:
接口->项目->分组
如果未拿到当前级别的浏览权限，将尝试读取上一级的浏览权限
所以对结果进行过滤至多将查询三次数据库(2+1+0)

- 这里存在的一个问题是,因为搜索处设置的limit为10，这将可能导致查出来的10个中部分不满足条件的数据被丢弃，而部分满足条件的又没有被补进来

- 在未考虑性能的情况下，我尝试过做简单的过滤 https://github.com/tangcent/yapi/commit/6a902c940dd46ec09896e7a1c7b731e2e0a02d74 在正常生产环境下亦未出现显著的性能问题

- 有效的改善了多端API类似的情况下不同端小伙伴的搜索体验

- 综上，还是需要评估此条PR提供的实现方式是否有效，多谢

- fix #1226



