### PR TITLE
fix: 修改Swagger自动同步信息时检查权限

### DIFF
--- a/exts/yapi-plugin-swagger-auto-sync/controller/syncController.js
+++ b/exts/yapi-plugin-swagger-auto-sync/controller/syncController.js
@@ -22,6 +22,11 @@ class syncController extends baseController {
     if (!projectId) {
       return (ctx.body = yapi.commons.resReturn(null, 408, '缺少项目Id'));
     }
+
+    if ((await this.checkAuth(projectId, 'project', 'edit')) !== true) {
+      return (ctx.body = yapi.commons.resReturn(null, 405, '没有权限'));
+    }
+
     let result;
     if (requestBody.id) {
       result = await this.syncModel.up(requestBody);


### PR DESCRIPTION
修改Swagger自动同步信息时检查对项目有edit权限

fix #1249
