### PR TITLE
当传入数据格式的 method 不规范时，容易导致获取对象为空，出现异常导致动态页面无法打开

### DIFF
--- a/client/components/TimeLine/TimeLine.js
+++ b/client/components/TimeLine/TimeLine.js
@@ -158,7 +158,7 @@ class TimeTree extends Component {
         <Option title={item.title} value={item._id + ''} path={item.path} key={item._id}>
           {item.title}{' '}
           <Tag
-            style={{ color: methodColor.color, backgroundColor: methodColor.bac, border: 'unset' }}
+            style={{color: methodColor ? methodColor.color : '#cfefdf', backgroundColor: methodColor ? methodColor.bac : '#00a854', border: 'unset'}}
           >
             {item.method}
           </Tag>

--- a/client/components/TimeLine/TimeLine.js
+++ b/client/components/TimeLine/TimeLine.js
@@ -158,7 +158,7 @@ class TimeTree extends Component {
         <Option title={item.title} value={item._id + ''} path={item.path} key={item._id}>
           {item.title}{' '}
           <Tag
-            style={{color: methodColor ? methodColor.color : '#cfefdf', backgroundColor: methodColor ? methodColor.bac : '#00a854', border: 'unset'}}
+            style={{ color: methodColor ? methodColor.color : '#cfefdf', backgroundColor: methodColor ? methodColor.bac : '#00a854', border: 'unset' }}
           >
             {item.method}
           </Tag>

--- a/exts/yapi-plugin-import-swagger/run.js
+++ b/exts/yapi-plugin-import-swagger/run.js
@@ -190,6 +190,7 @@ const compareVersions = require('compare-versions');
           required: param.required ? '1' : '0'
         };
 
+        if (param.in) {
         switch (param.in) {
           case 'path':
             api.req_params.push(defaultParam);
@@ -208,6 +209,9 @@ const compareVersions = require('compare-versions');
             api.req_headers.push(defaultParam);
             break;
         }
+      } else {
+        api.req_query.push(defaultParam);
+      }
       });
     }
 


### PR DESCRIPTION
通过插件导入的数据，很多情况下都会存在少量的格式不规范问题
https://github.com/YMFE/yapi/issues/1180