### PR TITLE
feat(数据管理): 支持定时数据导入

### DIFF
--- a/client/containers/Project/Setting/ProjectData/ProjectData.scss
+++ b/client/containers/Project/Setting/ProjectData/ProjectData.scss
@@ -1,7 +1,7 @@
 .postman-dataImport{
     display: flex;
     .dataImportCon{
-        min-width: 304px;
+        width: 304px;
         background-color: #ececec;
         padding: 16px;
         border-radius: 4px;
@@ -27,6 +27,7 @@
         }
 
         .dataSync{
+          text-align: left;
           padding-top: 16px;
           font-weight: 500;
           width: 100%;
@@ -50,7 +51,7 @@
 
         .url-import-content {
           text-align: center;
-          .url-btn{ 
+          .import-content-block-field, .url-btn{ 
             margin-top: 16px;
           }
         }
@@ -99,5 +100,3 @@
     margin-top: 10px;
   }
 }
-
-

--- a/client/reducer/modules/project.js
+++ b/client/reducer/modules/project.js
@@ -21,7 +21,12 @@ const CHECK_PROJECT_NAME = 'yapi/project/CHECK_PROJECT_NAME';
 const COPY_PROJECT_MSG = 'yapi/project/COPY_PROJECT_MSG';
 const PROJECT_GET_ENV = 'yapi/project/PROJECT_GET_ENV';
 const CHANGE_MEMBER_EMAIL_NOTICE = 'yapi/project/CHANGE_MEMBER_EMAIL_NOTICE';
-const GET_SWAGGER_URL_DATA = 'yapi/project/GET_SWAGGER_URL_DATA'
+const GET_SWAGGER_URL_DATA = 'yapi/project/GET_SWAGGER_URL_DATA';
+const SAVE_IMPORT_DATA_CRON_JOB = 'yapi/project/SAVE_IMPORT_DATA_CRON_JOB';
+const GET_IMPORT_DATA_CRON_JOB_LIST = 'yapi/project/GET_IMPORT_DATA_CRON_JOB_LIST';
+const DELETE_IMPORT_DATA_CRON_JOB = 'yapi/project/DELETE_IMPORT_DATA_CRON_JOB';
+const UPDATE_IMPORT_DATA_CRON_JOB_DISABLED = 'yapi/project/UPDATE_IMPORT_DATA_CRON_JOB_DISABLED';
+
 // Reducer
 const initialState = {
   isUpdateModalShow: false,
@@ -41,7 +46,8 @@ const initialState = {
       }
     ]
   },
-  swaggerUrlData: ''
+  swaggerUrlData: '',
+  importDataCronJobList: []
 };
 
 export default (state = initialState, action) => {
@@ -106,6 +112,14 @@ export default (state = initialState, action) => {
         swaggerUrlData: action.payload.data.data
       }
     }
+
+    case GET_IMPORT_DATA_CRON_JOB_LIST: {
+      return {
+        ...state,
+        importDataCronJobList: action.payload.data.data
+      }
+    }
+
     default:
       return state;
   }
@@ -332,6 +346,36 @@ export async function checkProjectName(name, group_id) {
 export async function handleSwaggerUrlData(url) {
   return {
     type: GET_SWAGGER_URL_DATA,
-    payload: axios.get('/api/project/swagger_url?url='+url)
+    payload: axios.get('/api/project/swagger_url', {
+      params: { url }
+    })
+  };
+}
+
+export async function saveImportDataCronJob(data) {
+  return {
+    type: SAVE_IMPORT_DATA_CRON_JOB,
+    payload: axios.post('/api/project/save_import_data_cron_job', data)
+  };
+}
+
+export async function getImportDataCronJobList(data) {
+  return {
+    type: GET_IMPORT_DATA_CRON_JOB_LIST,
+    payload: axios.post('/api/project/get_import_data_cron_job_list', data)
+  };
+}
+
+export async function deleteImportDataCronJob(data) {
+  return {
+    type: DELETE_IMPORT_DATA_CRON_JOB,
+    payload: axios.post('/api/project/delete_import_data_cron_job', data)
+  };
+}
+
+export async function updateImportDataCronJobDisabled(data) {
+  return {
+    type: UPDATE_IMPORT_DATA_CRON_JOB_DISABLED,
+    payload: axios.post('/api/project/update_import_data_cron_job_disabled', data)
   };
 }

--- a/server/app.js
+++ b/server/app.js
@@ -11,7 +11,8 @@ require('./plugin.js');
 const websockify = require('koa-websocket');
 const websocket = require('./websocket.js');
 const storageCreator = require('./utils/storage')
-require('./utils/notice')
+require('./utils/notice');
+require('./cron');
 
 const Koa = require('koa');
 const koaStatic = require('koa-static');

--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -15,7 +15,6 @@ const {
 } = require('../../common/postmanLib');
 const { handleParamsValue, ArrayToObject } = require('../../common/utils.js');
 const renderToHtml = require('../utils/reportHtml');
-const axios = require('axios');
 const HanldeImportData = require('../../common/HandleImportData');
 const _ = require('underscore');
 const createContex = require('../../common/createContext')

--- a/server/cron.js
+++ b/server/cron.js
@@ -1,0 +1,89 @@
+const moment = require('moment');
+const sha = require('sha.js');
+const axios = require('axios').default;
+const yapi = require('./yapi.js');
+const { getToken } = require('./utils/token');
+const { importDataCronJobModel, interfaceCatModel, projectModel, tokenModel } = require('./models');
+const importDataToYApi = require('../common/HandleImportData');
+
+const importDataModule = {};
+yapi.emitHook('import_data', importDataModule);
+
+const importDataCronJobInst = yapi.getInst(importDataCronJobModel);
+const interfaceCatInst = yapi.getInst(interfaceCatModel);
+const projectInst = yapi.getInst(projectModel);
+const tokenInst = yapi.getInst(tokenModel);
+
+setInterval(async () => {
+  try {
+    const jobs = await importDataCronJobInst.getRunnableJobs();
+    await Promise.all(
+      jobs.map(async job => {
+        await importDataCronJobInst.update(job._id, {
+          running: true,
+          next_run_at: moment().unix() + job.interval
+        });
+        switch (job.source.type) {
+          case 'swagger':
+            if (importDataModule.swagger) {
+              const { data: swaggerData } = await axios.get(job.source.url);
+              if (swaggerData != null && typeof swaggerData === 'object') {
+                const [yapiData, catList, projectData, token] = await Promise.all([
+                  importDataModule.swagger(swaggerData),
+                  interfaceCatInst.list(job.target.project_id),
+                  projectInst.get(job.target.project_id),
+                  getProjectToken(job.target.project_id, job.uid)
+                ]);
+                // 分类存在时导入；分类不存在时删除任务
+                if (catList.find(cat => cat._id === job.target.cat_id)) {
+                  await importDataToYApi(
+                    yapiData,
+                    job.target.project_id,
+                    job.target.cat_id,
+                    catList,
+                    projectData.basePath,
+                    job.mode,
+                    () => {},
+                    () => {},
+                    () => {},
+                    token,
+                    yapi.WEBCONFIG.port
+                  );
+                } else {
+                  await importDataCronJobInst.delete(job._id);
+                }
+              }
+            }
+            break;
+          default:
+            break;
+        }
+        await importDataCronJobInst.update(job._id, {
+          running: false
+        });
+      })
+    );
+  } catch(err) {
+    console.log(err);
+  }
+}, 1000 * 60);
+
+async function getProjectToken(project_id, uid) {
+  let token;
+
+  const data = await tokenInst.get(project_id);
+  if (!data) {
+    const passsalt = yapi.commons.randStr();
+    token = sha('sha1')
+      .update(passsalt)
+      .digest('hex')
+      .substr(0, 20);
+    await tokenInst.save({ project_id, token });
+  } else {
+    token = data.token;
+  }
+
+  token = getToken(token, uid);
+
+  return token
+}

--- a/server/models/importDataCronJob.js
+++ b/server/models/importDataCronJob.js
@@ -1,0 +1,94 @@
+const moment = require('moment');
+const baseModel = require('./base.js');
+
+const schema = {
+  /** 创建的用户 ID */
+  uid: { type: Number, required: true },
+  /** 导入数据合并模式：普通、智能、覆盖 */
+  mode: { type: String, enum: ['normal', 'good', 'merge'], required: true },
+  /** 导入数据来源 */
+  source: {
+    /** 数据类型，暂时只有 swagger */
+    type: { type: String, enum: ['swagger'], required: true },
+    /** 数据地址 */
+    url: { type: String, required: true }
+  },
+  /** 导入目标 */
+  target: {
+    /** 项目 ID */
+    project_id: { type: Number, required: true },
+    /** 分类 ID */
+    cat_id: { type: Number, required: true }
+  },
+  /** 每隔 x 秒执行一次，目前至少应为 60，即一分钟 */
+  interval: { type: Number, min: 60, required: true },
+  /** 定时的直观描述 */
+  interval_human: { type: String, required: true },
+  /** 下一次运行时间，以 unix 时间戳表示 */
+  next_run_at: { type: Number, required: true },
+  /** 是否正在运行 */
+  running: { type: Boolean, default: false },
+  /** 是否禁用 */
+  disabled: { type: Boolean, default: false }
+};
+
+const allFields = '_id ' + Object.keys(schema).join(' ');
+
+class importDataCronJobModel extends baseModel {
+  getName() {
+    return 'import_data_cron_job';
+  }
+
+  getSchema() {
+    return schema;
+  }
+
+  save(data) {
+    const m = new this.model(data);
+    return m.save();
+  }
+
+  getJobsByProjectId(project_id) {
+    return this.model
+      .find({
+        'target.project_id': project_id
+      })
+      .sort({ _id: -1 })
+      .select(allFields)
+      .exec();
+  }
+
+  getRunnableJobs() {
+    const now = moment().unix();
+    return this.model
+      .find({
+        running: false,
+        disabled: false,
+        next_run_at: { $lte: now }
+      })
+      .select(allFields)
+      .exec();
+  }
+
+  update(id, data) {
+    return this.model.update(
+      { _id: id },
+      data
+    );
+  }
+
+  delete(id) {
+    return this.model.remove({
+      _id: id
+    });
+  }
+
+  updateDisabled(id, disabled) {
+    return this.model.update(
+      { _id: id },
+      { disabled }
+    );
+  }
+}
+
+module.exports = importDataCronJobModel;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,15 @@
+// @index('./*', f => `exports.${f.name}Model = require('${f.path}');`)
+exports.avatarModel = require('./avatar');
+exports.baseModel = require('./base');
+exports.followModel = require('./follow');
+exports.groupModel = require('./group');
+exports.importDataCronJobModel = require('./importDataCronJob');
+exports.interfaceModel = require('./interface');
+exports.interfaceCaseModel = require('./interfaceCase');
+exports.interfaceCatModel = require('./interfaceCat');
+exports.interfaceColModel = require('./interfaceCol');
+exports.logModel = require('./log');
+exports.projectModel = require('./project');
+exports.storageModel = require('./storage');
+exports.tokenModel = require('./token');
+exports.userModel = require('./user');

--- a/server/router.js
+++ b/server/router.js
@@ -290,6 +290,26 @@ let routerConfig = {
       action: 'swaggerUrl',
       path: 'swagger_url',
       method: 'get'
+    },
+    {
+      action: 'saveImportDataCronJob',
+      path: 'save_import_data_cron_job',
+      method: 'post'
+    },
+    {
+      action: 'getImportDataCronJobList',
+      path: 'get_import_data_cron_job_list',
+      method: 'post'
+    },
+    {
+      action: 'deleteImportDataCronJob',
+      path: 'delete_import_data_cron_job',
+      method: 'post'
+    },
+    {
+      action: 'updateImportDataCronJobDisabled',
+      path: 'update_import_data_cron_job_disabled',
+      method: 'post'
     }
   ],
   interface: [


### PR DESCRIPTION
## 解决的问题

Swagger 数据定时导入是一个常见的需求，YApi 目前可通过 **设置** 里的 **Swagger自动同步插件** 实现。

但其存在以下问题或局限：

- 受限于插件机制，功能上虽属于数据管理模块，但放在了设置里面
- 不支持在一个项目里面建立多个定时导入任务
- 类 cron 的语法虽然灵活但是存在一定学习成本
- 一些社区反馈的问题也暂时没有得到修复

以上，本 PR 在 **数据管理** 模块下实现了更易用的 **定时数据导入** 功能，如图：

![image](https://user-images.githubusercontent.com/13151189/65756859-7cd8f900-e148-11e9-8e9f-e15bdf267f9f.png)

## 待解决的问题

- 目前数据导入 `完全覆盖` 模式的表现并不符合直觉，社区也提出了一些对这个模式的困惑，我觉得完全覆盖就应该删除所有再新增，毕竟还有智能模式。
- 作为过渡，本 PR 并未移除设置中的 **Swagger 自动同步** 插件，建议未来版本移除。