### PR TITLE
fix: use `sub` instead of `split` to parse parameters

### DIFF
--- a/client/containers/Project/Interface/InterfaceList/InterfaceEditForm.js
+++ b/client/containers/Project/Interface/InterfaceList/InterfaceEditForm.js
@@ -548,9 +548,12 @@ class InterfaceEditForm extends Component {
 
     this.state.bulkValue.split('\n').forEach((item, index) => {
       let valueItem = Object.assign({}, curValue[index] || dataTpl[this.state.bulkName]);
-      valueItem.name = item.split(':')[0];
-      valueItem.example = item.split(':')[1] || '';
-      newValue.push(valueItem);
+      let indexOfColon = item.indexOf(':');
+      if (indexOfColon!==-1) {
+        valueItem.name = item.substring(0, indexOfColon);
+        valueItem.example = item.substring(indexOfColon + 1) || '';
+        newValue.push(valueItem);
+      }
     });
 
     this.setState({


### PR DESCRIPTION
- 使用 `substring`来分割参数,防止参数值中包含`:`时被截断
fix #1493 
---
这里有个问题是如下这种情况:
```
aaa
bbb:
ccc:ddd
```
这里的`aaa`该不该当做一个参数录入?