### PR TITLE
write lock file to separate directory '{yapi.WEBROOT_RUNTIME}/data'

### DIFF
--- a/server/install.js
+++ b/server/install.js
@@ -136,7 +136,7 @@ function setupSql() {
 
       result.then(
         function() {
-          fs.ensureFileSync(yapi.path.join(yapi.WEBROOT_RUNTIME, 'init.lock'));
+          fs.ensureFileSync(yapi.path.join(yapi.WEBROOT_RUNTIME, 'data', 'init.lock'));
           console.log(
             `初始化管理员账号成功,账号名："${yapi.WEBCONFIG.adminAccount}"，密码："ymfe.org"`
           ); // eslint-disable-line


### PR DESCRIPTION
It is necessary to persist the lock file during containerized deployment, which is not easy to do if you store the lock file directly in the directory {yapi.webroot_runtime}.