### PR TITLE
feat: 在after-request钩子后可以展示自定义组件

### DIFF
--- a/client/components/Postman/Postman.js
+++ b/client/components/Postman/Postman.js
@@ -136,6 +136,7 @@ export default class Run extends Component {
       test_res_header: null,
       test_res_body: null,
       autoPreviewHTML: true,
+      injectList: [],
       ...this.props.data
     };
   }
@@ -158,8 +159,8 @@ export default class Run extends Component {
   handleReqHeader = (value, env) => {
     let index = value
       ? env.findIndex(item => {
-          return item.name === value;
-        })
+        return item.name === value;
+      })
       : 0;
     index = index === -1 ? 0 : index;
 
@@ -217,7 +218,7 @@ export default class Run extends Component {
     }
 
     let example = {}
-    if(this.props.type === 'inter'){
+    if (this.props.type === 'inter') {
       example = ['req_headers', 'req_query', 'req_body_form'].reduce(
         (res, key) => {
           res[key] = (data[key] || []).map(item => {
@@ -338,24 +339,31 @@ export default class Run extends Component {
     await plugin.emitHook('before_request', options, {
       type: this.props.type,
       caseId: options.caseId,
-      projectId: this.props.projectId,
-      interfaceId: this.props.interfaceId
+      interface: this.props.data
     });
 
     try {
       options.taskId = this.props.curUid;
-      result = await crossRequest(options, options.pre_script || this.state.pre_script, options.after_script || this.state.after_script, createContext(
+      result = await crossRequest(options, this.state.pre_script, this.state.after_script, createContext(
         this.props.curUid,
         this.props.projectId,
         this.props.interfaceId
       ));
 
-      await plugin.emitHook('after_request', result, {
+      let after_reault = await plugin.emitHook('after_request', result, {
         type: this.props.type,
         caseId: options.caseId,
-        projectId: this.props.projectId,
-        interfaceId: this.props.interfaceId
+        interface: this.props.data
       });
+
+      // 将接口返回的对应的组件渲染
+      let result_inject = after_reault.filter((rs) => (rs && rs.component));
+
+      if (result_inject.length) {
+        this.setState({
+          injectList: result_inject
+        });
+      }
 
       result = {
         header: result.res.header,
@@ -424,7 +432,6 @@ export default class Run extends Component {
   };
 
   changeParam = (name, v, index, key) => {
-    
     key = key || 'value';
     const pathParam = deepCopyJson(this.state[name]);
 
@@ -580,8 +587,15 @@ export default class Run extends Component {
       loading,
       case_env,
       inputValue,
-      hasPlugin
+      hasPlugin,
+      injectList
     } = this.state;
+
+    // 展示注入的组件
+    let injectComponent = injectList.length ? injectList.map(({ key, name, injectData, component: Comp }) => {
+      return (<Comp key={key} name={name} {...injectData} />);
+    }) : null;
+
     // console.log(env);
     return (
       <div className="interface-test postman">
@@ -934,7 +948,7 @@ export default class Run extends Component {
                 {this.state.resStatusCode + '  ' + this.state.resStatusText}
               </h2>
               <div>
-                <a rel="noopener noreferrer"  target="_blank" href="https://juejin.im/post/5c888a3e5188257dee0322af">YApi 新版如何查看 http 请求数据</a>
+                <a rel="noopener noreferrer" target="_blank" href="https://juejin.im/post/5c888a3e5188257dee0322af">YApi 新版如何查看 http 请求数据</a>
               </div>
               {this.state.test_valid_msg && (
                 <Alert
@@ -1045,6 +1059,7 @@ export default class Run extends Component {
             </Tabs.TabPane>
           ) : null}
         </Tabs>
+        {injectComponent}
       </div>
     );
   }

--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
@@ -315,8 +315,7 @@ class InterfaceColContent extends Component {
     await plugin.emitHook('before_col_request', Object.assign({}, options, {
       type: 'col',
       caseId: options.caseId,
-      projectId: interfaceData.project_id,
-      interfaceId: interfaceData.interface_id
+      interface: interfaceData
     }));
 
     try {
@@ -339,8 +338,7 @@ class InterfaceColContent extends Component {
       await plugin.emitHook('after_col_request', result, {
         type: 'col',
         caseId: options.caseId,
-        projectId: interfaceData.project_id,
-        interfaceId: interfaceData.interface_id
+        interface: interfaceData
       });
 
       if (options.data && typeof options.data === 'object') {

--- a/client/plugin.js
+++ b/client/plugin.js
@@ -72,7 +72,7 @@ hooks = {
     listener: []
   },
   /**
-   * 在运行页面或单个测试也里每次发送请求前调用
+   * 在运行页面或测试用例页接口发送请求前调用
    * 可以用插件针对某个接口的请求头或者数据进行修改或者记录
   */
   before_request: {
@@ -81,14 +81,28 @@ hooks = {
     listener: []
   },
   /**
-   * 在运行页面或单个测试也里每次发送完成后调用
-   * 返回值为响应原始值 + 
+   * 在运行页面或测试用例页接口发送完成后调用
+   * 返回给回调函数的值为响应原始值 + 
    * {
    *   type: 'inter' | 'case',
-   *   projectId: string,
-   *   interfaceId: string
+   *   caseId: string,
+   *   interface: 接口数据
    * }
-  */
+   * 
+   * @info
+   * hook函数为Promise, 会等待值返回后继续
+   * 返回值为指定格式时将作为组件放在最下面展示
+   * { 
+   *    name: '同步数据',
+   *    key: 'sync_schema_resp',
+   *    component: RespSchemaSync,
+   *    // 需要间接传给组件的props参数
+   *    injectData: {
+   *      message: validtor.message,
+   *      schema: transformJsonToSchema(result.res.body)
+   *    }
+   * }
+   */
   after_request: {
     type: 'listener',
     mulit: true,
@@ -108,8 +122,7 @@ hooks = {
    * {
    *   type: 'col',
    *   caseId: string,
-   *   projectId: string,
-   *   interfaceId: string
+   *   interface: 接口数据
    * }
   */
   after_col_request: {


### PR DESCRIPTION
可以针对after_request的hook的返回的值是组件时,将其渲染在页面中。
例如我加了一个[resp-schema-sync](https://github.com/AlexStacker/yapi-plugin-resp-schema-sync)插件可以将检查返回值和接口定义中的不一致时，弹窗提示是不是需要合并。

##### 返回值格式为:
```javascript
  {
    name: '同步数据',
    key: 'resp_schema_sync',
    component: RespSchemaSync,
    injectData: {
      message: validtor.message,
      schema: transformJsonToSchema(result.res.body)
    }
  }
```
检查返回值有`component`组件就会渲染, 并将额外的`injectData`会传给组件中。