### PR TITLE
fix: schema2json传required参数时，导致faker失败

### DIFF
--- a/server/controllers/interface.js
+++ b/server/controllers/interface.js
@@ -1180,7 +1180,7 @@ class interfaceController extends baseController {
     let required = ctx.request.body.required;
 
     let res = yapi.commons.schemaToJson(schema, {
-      alwaysFakeOptionals: _.isUndefined(required) ? true : require
+      alwaysFakeOptionals: _.isUndefined(required) ? true : required
     });
     // console.log('res',res)
     return (ctx.body = res);


### PR DESCRIPTION
当传了required参数时，由于三目运算符属性写错，导致alwaysFakeOptionals属性设置错误