### PR TITLE
自动化测试时服务端测试node默认2分钟没有返回就直接断掉连接，可以手动设置一个超时时间。

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,7 @@
 {
   "port": "3000",
   "adminAccount": "admin@admin.com",
+  "timeout":120000,
   "db": {
     "servername": "127.0.0.1",
     "DATABASE": "yapi",

--- a/server/app.js
+++ b/server/app.js
@@ -54,9 +54,14 @@ app.use(async (ctx, next) => {
   await next();
 });
 
+
 app.use(koaStatic(yapi.path.join(yapi.WEBROOT, 'static'), { index: indexFile, gzip: true }));
 
-app.listen(yapi.WEBCONFIG.port);
+
+const server = app.listen(yapi.WEBCONFIG.port);
+
+server.setTimeout(yapi.WEBCONFIG.timeout);
+
 commons.log(
   `服务已启动，请打开下面链接访问: \nhttp://127.0.0.1${
     yapi.WEBCONFIG.port == '80' ? '' : ':' + yapi.WEBCONFIG.port


### PR DESCRIPTION
自动化测试时服务端测试node默认2分钟没有返回就直接断掉连接，可以手动设置一个超时时间。
#1455
#705