### PR TITLE
feat: 自动化测试报告保存，邮件返回测试报告地址

### DIFF
--- a/server/controllers/base.js
+++ b/server/controllers/base.js
@@ -29,7 +29,8 @@ class baseController {
       '/api/user/status',
       '/api/user/logout',
       '/api/user/avatar',
-      '/api/user/login_by_ldap'
+      '/api/user/login_by_ldap',
+      '/api/report/get_report'
     ];
     if (ignoreRouter.indexOf(ctx.path) > -1) {
       this.$auth = true;

--- a/server/controllers/interfaceAutoReportController.js
+++ b/server/controllers/interfaceAutoReportController.js
@@ -1,0 +1,42 @@
+const interfaceColModel = require('../models/interfaceCol.js');
+const interfaceCaseModel = require('../models/interfaceCase.js');
+const interfaceModel = require('../models/interface.js');
+const projectModel = require('../models/project.js');
+const baseController = require('./base.js');
+const interfaceAutoReport = require("../models/interfaceAutoReport.js");
+const yapi = require('../yapi.js');
+const _ = require('underscore');
+
+class interfaceAutoReportController extends baseController {
+  constructor(ctx) {
+    super(ctx);
+    this.autoReport = yapi.getInst(interfaceAutoReport);
+  }
+
+  /**
+   * 获取一个测试用例详情
+   * @interface /report/get_report
+   * @method GET
+   * @category report
+   * @foldnumber 10
+   * @param {String} reportid
+   * @returns {Object}
+   * @example
+   */
+  async getReport(ctx) {
+
+    try {
+      let id = ctx.params.reportid;
+      let result = await this.autoReport.get(id);
+      if (!result) {
+        return (ctx.body = yapi.commons.resReturn(null, 400, '不存在的报告'));
+      }
+      result = result.toObject();
+      ctx.body = result.report;
+    } catch (e) {
+      ctx.body = yapi.commons.resReturn(null, 400, e.message);
+    }
+  }
+}
+
+module.exports = interfaceAutoReportController;

--- a/server/controllers/open.js
+++ b/server/controllers/open.js
@@ -273,7 +273,7 @@ class openController extends baseController {
     if (ctx.params.mode === 'json') {
       //保存测试报告
       let result = await this.reportInst.save({
-        report: reportsResult,
+        report: JSON.stringify(reportsResult),
         uid: this.getUid(),
         add_time: yapi.commons.time(),
         up_time: yapi.commons.time() 

--- a/server/install.js
+++ b/server/install.js
@@ -134,6 +134,11 @@ function setupSql() {
         project_id: 1
       });
 
+      let interfaceAutoReport = mongoose.connection.db.collection('interface_auto_report');
+      interfaceAutoReport.createIndex({
+        uid: 1
+      });
+
       result.then(
         function() {
           fs.ensureFileSync(yapi.path.join(yapi.WEBROOT_RUNTIME, 'init.lock'));

--- a/server/models/interfaceAutoReport.js
+++ b/server/models/interfaceAutoReport.js
@@ -1,0 +1,110 @@
+const yapi = require('../yapi.js');
+const baseModel = require('./base.js');
+
+class interfaceAutoReport extends baseModel {
+  getName() {
+    return 'interface_auto_report';
+  }
+
+  getSchema() {
+    return {
+      uid: { type: Number, required: true },
+      desc: String,
+      add_time: Number,
+      up_time: Number,
+      index: { type: Number, default: 0 },
+      report: { type: String, default: '{}' },
+      checkHttpCodeIs200: {
+        type:Boolean,
+        default: false
+      },
+      checkResponseSchema: {
+        type:Boolean,
+        default: false
+      },
+      checkResponseField: {
+        name: {
+          type: String,
+          required: true,
+          default: "code"
+        },
+        value: {
+          type: String,
+          required: true,
+          default: "0"
+        },
+        enable: {
+          type: Boolean,
+          default: false
+        }
+      },
+      checkScript: {
+        content: {
+          type: String
+        },
+        enable: {
+          type: Boolean,
+          default: false
+        }
+      }
+    };
+  }
+
+  save(data) {
+    let m = new this.model(data);
+    return m.save();
+  }
+
+  get(id) {
+    return this.model
+      .findOne({
+        _id: id
+      })
+      .exec();
+  }
+
+
+  list(col_id) {
+    return this.model
+      .find({
+        col_id: col_id
+      })
+      .select('name uid col_id desc add_time up_time, index')
+      .exec();
+  }
+
+  del(id) {
+    return this.model.remove({
+      _id: id
+    });
+  }
+
+  delByProjectId(id) {
+    return this.model.remove({
+      project_id: id
+    });
+  }
+
+  up(id, data) {
+    data.up_time = yapi.commons.time();
+    return this.model.update(
+      {
+        _id: id
+      },
+      data
+    );
+  }
+
+  upColIndex(id, index) {
+    return this.model.update(
+      {
+        _id: id
+      },
+      {
+        index: index
+      }
+    );
+  }
+}
+
+module.exports = interfaceAutoReport;

--- a/server/router.js
+++ b/server/router.js
@@ -4,7 +4,7 @@ const groupController = require('./controllers/group.js');
 const userController = require('./controllers/user.js');
 const interfaceColController = require('./controllers/interfaceCol.js');
 const testController = require('./controllers/test.js');
-
+const interfaceAutoReportController = require('./controllers/interfaceAutoReportController.js')
 const yapi = require('./yapi.js');
 const projectController = require('./controllers/project.js');
 const logController = require('./controllers/log.js');
@@ -50,7 +50,11 @@ let INTERFACE_CONFIG = {
   open: {
     prefix: '/open/',
     controller: openController
-  }
+  },
+  report: {
+    prefix: '/report/',
+    controller: interfaceAutoReportController
+  },
 };
 
 let routerConfig = {
@@ -577,6 +581,13 @@ let routerConfig = {
       action: 'importData',
       path: 'import_data',
       method: 'post'
+    }
+  ],
+  report: [
+    {
+      action: 'getReport',
+      path: 'get_report',
+      method: 'get'
     }
   ]
 };


### PR DESCRIPTION
保存测试报告到MongoDB中，并且发送邮件时返回测试报告访问地址。