### PR TITLE
fix: use lodash compare json other than lib isDeepMatch

### DIFF
--- a/exts/yapi-plugin-advanced-mock/server.js
+++ b/exts/yapi-plugin-advanced-mock/server.js
@@ -3,7 +3,7 @@ const advModel = require('./advMockModel.js');
 const caseModel = require('./caseModel.js');
 const yapi = require('yapi.js');
 const mongoose = require('mongoose');
-const _ = require('underscore');
+const _ = require("lodash");
 const path = require('path');
 const lib = require(path.resolve(yapi.WEBROOT, 'common/lib.js'));
 const Mock = require('mockjs');
@@ -59,7 +59,7 @@ module.exports = function() {
     let matchList = [];
     listWithIp.forEach(item => {
       let params = item.params;
-      if (item.case_enable && lib.isDeepMatch(reqParams, params)) {
+      if (item.case_enable && _.isEqual(reqParams, params)) {
         matchList.push(item);
       }
     });
@@ -74,7 +74,7 @@ module.exports = function() {
         .select('_id params case_enable');
       list.forEach(item => {
         let params = item.params;
-        if (item.case_enable && lib.isDeepMatch(reqParams, params)) {
+        if (item.case_enable && _.isEqual(reqParams, params)) {
           matchList.push(item);
         }
       });


### PR DESCRIPTION
弃用自定义且校验逻辑有问题的 isDeepMatch 方法，使用 lodash 的 isEqual 方法比较参数