### PR TITLE
修复报错‘col_id不能为空’问题

### DIFF
--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
@@ -483,7 +483,7 @@ class InterfaceColContent extends Component {
   async componentWillReceiveProps(nextProps) {
     let newColId = !isNaN(nextProps.match.params.actionId) ? +nextProps.match.params.actionId : 0;
 
-    if ((newColId && this.currColId && newColId !== this.currColId) || nextProps.isRander) {
+    if (newColId && ((this.currColId && newColId !== this.currColId) || nextProps.isRander)) {
       this.currColId = newColId;
       this.handleColIdChange(newColId)
     }

--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColMenu.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColMenu.js
@@ -436,7 +436,7 @@ export default class InterfaceColMenu extends Component {
       } else {
         return {
           expands: this.state.expands ? this.state.expands : ['col_' + interfaceColList[0]._id],
-          selects: ['root']
+          selects: ['col_' + interfaceColList[0]._id]
         };
       }
     };

--- a/server/controllers/interfaceCol.js
+++ b/server/controllers/interfaceCol.js
@@ -334,7 +334,7 @@ class interfaceColController extends baseController {
       }
 
       params.uid = this.getUid();
-      params.index = 0;
+      //params.index = 0;
       params.add_time = yapi.commons.time();
       params.up_time = yapi.commons.time();
       let result = await this.caseModel.save(params);
@@ -384,10 +384,12 @@ class interfaceColController extends baseController {
       if (!params.col_id) {
         return (ctx.body = yapi.commons.resReturn(null, 400, '接口集id不能为空'));
       }
-
+      
+      let maxIndexModel = await this.caseModel.getMaxIndex();
+      let maxIndex = maxIndexModel.index;
       let data = {
         uid: this.getUid(),
-        index: 0,
+        index: maxIndex,
         add_time: yapi.commons.time(),
         up_time: yapi.commons.time(),
         project_id: params.project_id,

--- a/server/models/interfaceCase.js
+++ b/server/models/interfaceCase.js
@@ -130,6 +130,10 @@ class interfaceCase extends baseModel {
       }
     );
   }
+  
+  getMaxIndex(){
+    return this.model.findOne().sort({index:-1}).limit(1).exec();
+  }
 }
 
 module.exports = interfaceCase;


### PR DESCRIPTION
修复切换测试集合未默认选中任一集合，且拖拽调整用例顺序时报错‘col_id不能为空’