### PR TITLE
Fix interfaceCol 报错'col_id不能为空'

### DIFF
--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColContent.js
@@ -483,7 +483,7 @@ class InterfaceColContent extends Component {
   async componentWillReceiveProps(nextProps) {
     let newColId = !isNaN(nextProps.match.params.actionId) ? +nextProps.match.params.actionId : 0;
 
-    if ((newColId && this.currColId && newColId !== this.currColId) || nextProps.isRander) {
+    if (newColId && ((this.currColId && newColId !== this.currColId) || nextProps.isRander)) {
       this.currColId = newColId;
       this.handleColIdChange(newColId)
     }

--- a/client/containers/Project/Interface/InterfaceCol/InterfaceColMenu.js
+++ b/client/containers/Project/Interface/InterfaceCol/InterfaceColMenu.js
@@ -436,7 +436,7 @@ export default class InterfaceColMenu extends Component {
       } else {
         return {
           expands: this.state.expands ? this.state.expands : ['col_' + interfaceColList[0]._id],
-          selects: ['root']
+          selects: ['col_' + interfaceColList[0]._id]
         };
       }
     };


### PR DESCRIPTION
修复测试集合报错'col_id不能为空' 