### PR TITLE
fix(swaggerjson中formData格式example属性在yapi页面不显示)

### DIFF
--- a/exts/yapi-plugin-import-swagger/run.js
+++ b/exts/yapi-plugin-import-swagger/run.js
@@ -240,6 +240,9 @@ const compareVersions = require('compare-versions');
             break;
           case 'formData':
             defaultParam.type = param.type === 'file' ? 'file' : 'text';
+			if (param.example) {
+              defaultParam.example = param.example;
+            }
             api.req_body_form.push(defaultParam);
             break;
           case 'header':


### PR DESCRIPTION
修复swaggerjson导入yapi中时，formData格式的example属性在yapi页面示例中不显示问题