### PR TITLE
fix: check curProject before call Object.keys

### DIFF
--- a/client/containers/Project/Project.js
+++ b/client/containers/Project/Project.js
@@ -139,7 +139,7 @@ export default class Project extends Component {
       });
     }
 
-    if (Object.keys(this.props.curProject).length === 0) {
+    if (this.props.curProject == null || Object.keys(this.props.curProject).length === 0) {
       return <Loading visible />;
     }
 


### PR DESCRIPTION
fix `Uncaught TypeError: Cannot convert undefined or null to object` while the curProject is null.