### PR TITLE
swagger定时同步

### DIFF
--- a/exts/yapi-plugin-swagger-auto-sync/interfaceSyncUtils.js
+++ b/exts/yapi-plugin-swagger-auto-sync/interfaceSyncUtils.js
@@ -98,7 +98,7 @@ class syncUtils {
             //记录日志
             // this.saveSyncLog(0, syncMode, "接口无更新", uid, projectId);
             oldSyncJob.last_sync_time = yapi.commons.time();
-            await this.syncModel.upById(projectId, oldSyncJob);
+            await this.syncModel.upById(oldSyncJob._id, oldSyncJob);
             return;
         }
 

--- a/exts/yapi-plugin-swagger-auto-sync/interfaceSyncUtils.js
+++ b/exts/yapi-plugin-swagger-auto-sync/interfaceSyncUtils.js
@@ -96,7 +96,7 @@ class syncUtils {
         //更新之前判断本次swagger json数据是否跟上次的相同,相同则不更新
         if (newSwaggerJsonData && oldSyncJob.old_swagger_content && oldSyncJob.old_swagger_content == md5(newSwaggerJsonData)) {
             //记录日志
-            this.saveSyncLog(0, syncMode, "接口无更新", uid, projectId);
+            // this.saveSyncLog(0, syncMode, "接口无更新", uid, projectId);
             oldSyncJob.last_sync_time = yapi.commons.time();
             await this.syncModel.upById(projectId, oldSyncJob);
             return;


### PR DESCRIPTION
1.接口无更新,不保存日志
2.syncInterface 接口无更新,修改sync_model的属性失败