### PR TITLE
修复swagger url导入不支持中文的问题

### DIFF
--- a/client/reducer/modules/project.js
+++ b/client/reducer/modules/project.js
@@ -332,6 +332,6 @@ export async function checkProjectName(name, group_id) {
 export async function handleSwaggerUrlData(url) {
   return {
     type: GET_SWAGGER_URL_DATA,
-    payload: axios.get('/api/project/swagger_url?url='+url)
+    payload: axios.get('/api/project/swagger_url?url='+encodeURI(encodeURI(url)))
   };
 }


### PR DESCRIPTION
已测试通过，由于数据导入和定时同步都是调用的`handleSwaggerUrlData`方法，所以这两个点都可以正常使用了。

相关issue：
- https://github.com/YMFE/yapi/issues/2026
- https://github.com/YMFE/yapi/issues/1371