### PR TITLE
fix: fixed install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "generate-schema": "^2.6.0",
     "immer": "^1.1.1",
     "js-base64": "^2.3.2",
-    "json-schema-faker": "^0.5.0-rc16",
+    "json-schema-faker": "0.5.0-rc16",
     "json-schema-ref-parser": "4.0.0",
     "json5": "0.5.1",
     "jsondiffpatch": "0.3.11",


### PR DESCRIPTION
修复安装时抛出`TypeError: jsf.extend is not a function`的异常

https://github.com/YMFE/yapi/issues/2226
https://github.com/YMFE/yapi/issues/2228