### PR TITLE
fix: 修复导出html接口文档时，不同目录下有相同接口名导致的接口错位问题

### DIFF
--- a/common/markdown.js
+++ b/common/markdown.js
@@ -258,7 +258,7 @@ function createInterMarkdown(basepath, listItem, isToc) {
   let mdTemplate = ``;
   const toc = `[TOC]\n\n`;
   // 接口名称
-  mdTemplate += `\n## ${escapeStr(`${listItem.title}\n<a id=${listItem.title}> </a>`, isToc)}\n`;
+  mdTemplate += `\n## ${escapeStr(`${listItem.title}\n<a id=${listItem.title + listItem.catid}> </a>`, isToc)}\n`;
   isToc && (mdTemplate += toc);
   // 基本信息
   mdTemplate += createBaseMessage(basepath, listItem);


### PR DESCRIPTION
<img width="811" alt="正确的接口" src="https://user-images.githubusercontent.com/21303785/126414118-9d0edbb9-e005-45c2-a232-358b15d21e54.png">
<img width="913" alt="错位的接口2" src="https://user-images.githubusercontent.com/21303785/126414123-692f774c-7cd0-4bdf-b930-55fceee1c5b3.png">
<img width="939" alt="错位的接口1" src="https://user-images.githubusercontent.com/21303785/126414125-40ef138c-98fa-4106-863b-4f090971cf93.png">
如图所示我在三个文件夹分类下都有叫列表的接口，导出的菜单都定位到了技术服务费的列表接口位置。
debug后发现html是markdown转的，转的时候接口名的div id就是接口名，相同的接口名导致div id重复。故我在将div id设为了“接口名+catid”的格式，避免出现相同div id 