### PR TITLE
fix: 修复导出html接口文档时，不同目录下有相同接口名导致的接口错位问题 (#2270)

### DIFF
--- a/common/markdown.js
+++ b/common/markdown.js
@@ -258,7 +258,7 @@ function createInterMarkdown(basepath, listItem, isToc) {
   let mdTemplate = ``;
   const toc = `[TOC]\n\n`;
   // 接口名称
-  mdTemplate += `\n## ${escapeStr(`${listItem.title}\n<a id=${listItem.title}> </a>`, isToc)}\n`;
+  mdTemplate += `\n## ${escapeStr(`${listItem.title}\n<a id=${listItem.title + listItem.catid}> </a>`, isToc)}\n`;
   isToc && (mdTemplate += toc);
   // 基本信息
   mdTemplate += createBaseMessage(basepath, listItem);


### PR DESCRIPTION
Co-authored-by: wangxl <wangxl@onton.net>