### PR TITLE
fix: read project_id from cat

### DIFF
--- a/server/controllers/interface.js
+++ b/server/controllers/interface.js
@@ -393,7 +393,15 @@ class interfaceController extends baseController {
     //检查是否提交了目前不存在的tag
     let tags = params.tag;
     if (tags && Array.isArray(tags) && tags.length > 0) {
-      let projectData = await this.projectModel.get(params.project_id);
+      let project_id = params.project_id;
+      if(!project_id){
+        let catData = await this.catModel.get(params.catid);
+        project_id = catData.project_id;
+      }
+      let projectData = await this.projectModel.get(project_id);
+      if(!projectData){
+        return
+      }
       let tagsInProject = projectData.tag;
       let needUpdate = false;
       if (tagsInProject && Array.isArray(tagsInProject) && tagsInProject.length > 0) {

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -82,6 +82,9 @@ class projectModel extends baseModel {
   }
 
   handleEnvNullData(data){
+    if(!data){
+      return
+    }
     data = data.toObject();
     data.toObject = ()=> data;
     let isFix = false;


### PR DESCRIPTION
更新时`project_id`非必须字段，更新接口作为`openapi`需对此保持兼容.
故当`project_id`不存在时，尝试从`cat_id`取`project`.

---

fix #2371