### PR TITLE
Update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6282,8 +6282,8 @@
       }
     },
     "dify": {
-      "version": "1.0.5",
-      "resolved": "https://repo.corp.qunar.com/artifactory/api/npm/npm-qunar/dify/download/dify-1.0.5.tgz",
+      "version": "1.0.6",
+      "resolved": "http://registry.npm.taobao.org/dify/download/dify-1.0.6.tgz",
       "integrity": "sha1-LpsBVOwTCrklVyasTOzrnXM4zwM="
     },
     "dir-glob": {


### PR DESCRIPTION
修改dify版本及地址。
原代码中的https://repo.corp.qunar.com/artifactory/api/npm/npm-qunar/dify/download/dify-1.0.5.tgz 访问不到。