### PR TITLE
禁用切换分组调用log

### DIFF
--- a/client/containers/Group/GroupList/GroupList.js
+++ b/client/containers/Group/GroupList/GroupList.js
@@ -175,7 +175,7 @@ export default class GroupList extends Component {
     });
     this.props.setCurrGroup(currGroup);
     this.props.history.replace(`${currGroup._id}`);
-    this.props.fetchNewsData(groupId, 'group', 1, 10);
+    // this.props.fetchNewsData(groupId, 'group', 1, 10);
   }
 
   @autobind


### PR DESCRIPTION
切换分组时调用日志会产生大量的日志请求，并且没有看到在哪里用到这份日志数据。
关掉之后显著降低了MongoDB的压力。