### PR TITLE
support bindIP for web security

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,4 +1,5 @@
 {
+  "bindIP": "127.0.0.1",
   "port": "3000",
   "adminAccount": "admin@admin.com",
   "timeout":120000,

--- a/server/app.js
+++ b/server/app.js
@@ -58,12 +58,15 @@ app.use(async (ctx, next) => {
 app.use(koaStatic(yapi.path.join(yapi.WEBROOT, 'static'), { index: indexFile, gzip: true }));
 
 
-const server = app.listen(yapi.WEBCONFIG.port);
+const bindIP = yapi.WEBCONFIG.bindIP || "0.0.0.0"
+const server = app.listen(yapi.WEBCONFIG.port, bindIP);
 
 server.setTimeout(yapi.WEBCONFIG.timeout);
 
+const displayIP = bindIP == '0.0.0.0' ? '127.0.0.1': bindIP
+
 commons.log(
-  `服务已启动，请打开下面链接访问: \nhttp://127.0.0.1${
+  `服务已启动，请打开下面链接访问: \nhttp://${displayIP}${
     yapi.WEBCONFIG.port == '80' ? '' : ':' + yapi.WEBCONFIG.port
   }/`
 );


### PR DESCRIPTION
Hi,

Binding IP is an universal approach to gurantee Web security, especially in case of reverse proxy. As for non FEers, adding this feature is not easy. It could be better to support "bindIP" feature explicitly.