### PR TITLE
feat: make select and copy path easier in API list

### DIFF
--- a/client/containers/Project/Interface/InterfaceList/InterfaceList.js
+++ b/client/containers/Project/Interface/InterfaceList/InterfaceList.js
@@ -236,6 +236,7 @@ class InterfaceList extends Component {
               <Tooltip title="开放接口" placement="topLeft">
                 <span>{record.api_opened && <Icon className="opened" type="eye-o" />}</span>
               </Tooltip>
+              {' '}
               <Tooltip title={path} placement="topLeft" overlayClassName="toolTip">
                 <span className="path">{path}</span>
               </Tooltip>


### PR DESCRIPTION
This change adds a whitespace between method and path. Without the whitespace, selecting the full path also selects the last character of the tag.
