### PR TITLE
fix: 修复接口更新存在tag变化，提示更行失败

### DIFF
--- a/server/controllers/interface.js
+++ b/server/controllers/interface.js
@@ -822,6 +822,7 @@ class interfaceController extends baseController {
     }
 
     yapi.emitHook('interface_update', id).then();
+    params.project_id = interfaceData.project_id;
     await this.autoAddTag(params);
 
     ctx.body = yapi.commons.resReturn(result);


### PR DESCRIPTION
修复一个报错，原因是更新接口操作，参数中没有project_id