### PR TITLE
支持将swagger扩展属性映射为yapi字段

### DIFF
--- a/exts/yapi-plugin-import-swagger/run.js
+++ b/exts/yapi-plugin-import-swagger/run.js
@@ -154,6 +154,18 @@ const compareVersions = require('compare-versions');
     api.title = data.summary || data.path;
     api.desc = data.description;
     api.catname = null;
+
+    // 处理 swagger 扩展属性
+    // 如: x-yapi-status 映射为 yapi status字段
+    const extPrefix = 'x-yapi-';
+    _.each(api, (value, extfield) => {
+      if (extfield.startsWith(extPrefix)) {
+        const yapiField = extfield.replace(extPrefix, '');
+        api[yapiField] = value;
+        delete api[extfield];
+      }
+    })
+
     if(data.tags && Array.isArray(data.tags)){
       api.tag = data.tags;
       for(let i=0; i< data.tags.length; i++){


### PR DESCRIPTION
## 说明

支持将swagger扩展属性映射为yapi字段，如，可通过扩展属性维护接口开发状态：

`"x-yapi-status": "done"`
or
`"x-yapi-status": "undone"`

## 使用举例

以@nestjs/swagger为例
1. 添加`@ApiExtension注解并定义拓展属性`：
`@ApiExtesion('x-yapi-status', 'done')`
2. yapi中导入swagger文档
