### PR TITLE
fix:修复更新接口时没有project_id参数问题

### DIFF
--- a/server/controllers/interface.js
+++ b/server/controllers/interface.js
@@ -822,6 +822,7 @@ class interfaceController extends baseController {
     }
 
     yapi.emitHook('interface_update', id).then();
+    params.project_id = interfaceData.project_id;
     await this.autoAddTag(params);
 
     ctx.body = yapi.commons.resReturn(result);


### PR DESCRIPTION
问题：
更新接口时的autoAddTag方法需要project_id参数，但是接口里没有该参数。

备注：
本想着在前端加上这个参数，保持一致的接口风格，但是想了一下还是用后端已经拿到的数据覆盖吧。也许作者会有其他考虑，有更统一的修改方案，姑且还是先提一下pr吧。也算作为其他遇到该问题的朋友给个提示