### PR TITLE
fix:  use single instance sandbox coz destroy() can't free up memory

### DIFF
--- a/server/utils/sandbox.js
+++ b/server/utils/sandbox.js
@@ -1,17 +1,35 @@
 const Safeify = require('safeify').default;
+const safeVm = new Safeify({
+  timeout: 3000,
+  asyncTimeout: 60000,
+  // true为不受CPU限制，以解决Docker启动问题
+  unrestricted: true,
+  unsafe: {
+    modules: {
+      // 引入assert断言库
+      assert: 'assert'
+    }
+  }
+});
+safeVm.preset('const assert = require("assert");');
 
 module.exports = async function sandboxFn(context, script) {
-    // 创建 safeify 实例
-    const safeVm = new Safeify({
-        timeout: 3000,
-        asyncTimeout: 60000
-    })
+  script += `; return {
+        Function: this.Function,
+        eval: this.eval,
+        header: this.header,
+        query: this.query,
+        body: this.body,
+        mockJson: this.mockJson,
+        params: this.params,
+        resHeader: this.resHeader,
+        httpCode: this.httpCode,
+        delay: this.delay,
+        Random: this.Random,
+        cookie: this.cookie
+    }`;
 
-    script += "; return this;";
-    // 执行动态代码
-    const result = await safeVm.run(script, context)
-
-    // 释放资源
-    safeVm.destroy()
-    return result
-}
+  // 执行动态代码
+  const result = await safeVm.run(script, context);
+  return result;
+};


### PR DESCRIPTION
Safeify沙箱内存泄漏。
![微信图片编辑_20230222202158](https://user-images.githubusercontent.com/1421701/220618386-0035cbdd-bfa4-4207-87ee-615821a7c40b.jpg)
